### PR TITLE
ci: npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,14 @@
 #            credential).
 #   crates — secret CARGO_REGISTRY_TOKEN (scoped publish-only token from
 #            https://crates.io/settings/tokens).
-#   npm    — secret NPM_TOKEN (granular, publish-only, @responsibleai
-#            scope); `--provenance` attaches build provenance.
+#   npm    — trusted publishing (OIDC): configure a trusted publisher
+#            on the package (repo responsibleai/agent-hooks, workflow
+#            release.yml, environment release) at
+#            npmjs.com > package > Settings > Trusted Publisher.
+#            No token. First-ever publish of a new package cannot use
+#            trusted publishing — bootstrap once with a granular token
+#            (npm publish from a maintainer machine or a temporary
+#            NPM_TOKEN secret), then configure the publisher.
 #   NuGet  — secret NUGET_API_KEY (scoped to ResponsibleAI.AgentHooks).
 #   Go     — no registry: the module proxy serves the git tag directly.
 name: release
@@ -123,12 +129,16 @@ jobs:
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2
         with:
           subject-path: sdk/typescript/*.tgz
-      - name: Publish to npm (with provenance)
+      - name: Publish to npm (trusted publishing)
         if: env.DRY_RUN != 'true'
-        run: npm publish --provenance --access public
+        # OIDC trusted publishing: no token. Requires npm >= 11.5.1 and a
+        # trusted publisher configured on the package (repo
+        # responsibleai/agent-hooks, workflow release.yml, environment
+        # release). Provenance is generated automatically; note npm
+        # provenance requires a PUBLIC source repo — while this repo is
+        # private, expect the publish step to fail on the provenance leg.
+        run: npm install -g npm@latest && npm publish --access public
         working-directory: sdk/typescript
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   dotnet:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,13 @@ jobs:
         # release). Provenance is generated automatically; note npm
         # provenance requires a PUBLIC source repo — while this repo is
         # private, expect the publish step to fail on the provenance leg.
-        run: npm install -g npm@latest && npm publish --access public
+        # Prerelease versions publish under the `alpha` dist-tag (npm
+        # requires an explicit tag for prereleases); stable under latest.
+        run: |
+          npm install -g npm@latest
+          V=$(node -p "require('./package.json').version")
+          case "$V" in *-*) T=alpha;; *) T=latest;; esac
+          npm publish --access public --tag "$T"
         working-directory: sdk/typescript
 
   dotnet:

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -9,10 +9,15 @@
     ".": "./dist/index.js",
     "./ctk": "./dist/ctk/index.js"
   },
-  "files": ["dist", "binding.js", "binding.d.ts", "*.node"],
+  "files": [
+    "dist",
+    "binding.js",
+    "binding.d.ts",
+    "*.node"
+  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/responsibleai/agent-hooks.git",
+    "url": "git+https://github.com/responsibleai/agent-hooks.git",
     "directory": "sdk/typescript"
   },
   "napi": {
@@ -32,5 +37,7 @@
     "@types/node": "^22.0.0",
     "typescript": "^5.5.0"
   },
-  "engines": { "node": ">=20" }
+  "engines": {
+    "node": ">=20"
+  }
 }


### PR DESCRIPTION
Replaces the granular-token publish in the typescript release job with npm OIDC trusted publishing (npm >= 11.5.1; provenance automatic). Header documents the trusted-publisher configuration and the new-package bootstrap caveat.