### PR TITLE
ci: run the drift check on every PR

### DIFF
--- a/.github/workflows/schema-drift.yml
+++ b/.github/workflows/schema-drift.yml
@@ -1,15 +1,13 @@
 name: schema-drift
 
+# No path filter on pull_request: `drift` is a required check, and a
+# path-filtered required check deadlocks every PR that doesn't match the
+# filter (GitHub never creates the check run, so the branch protection
+# waits forever). The job is cheap; run it on every PR.
 on:
   push:
     branches: [main]
   pull_request:
-    paths:
-      - "spec/schema/**"
-      - "scripts/**"
-      - "sdk/python/python/agent_hooks/schema/**"
-      - "conformance/vectors/**"
-      - "sdk/python/python/agent_hooks/ctk/vectors/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
`drift` is a required status check, but the workflow's `paths:` filter means PRs outside the filter never get a check run — branch protection waits forever, deadlocking the whole queue (currently #4-#12). Removing the PR path filter makes the check always report; the job costs ~30 seconds. pull_request workflows execute from the merge ref, so this PR itself exercises the fix.