### PR TITLE
ci: crates.io and NuGet via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,11 @@
 #            https://pypi.org/manage/project/agent-hooks-sdk/settings/publishing/
 #            (no token; the `id-token: write` permission below is the
 #            credential).
-#   crates — secret CARGO_REGISTRY_TOKEN (scoped publish-only token from
-#            https://crates.io/settings/tokens).
+#   crates — trusted publishing (OIDC): configure the publisher on the
+#            crate (repo responsibleai/agent-hooks, workflow release.yml,
+#            environment release) at
+#            https://crates.io/crates/agent-hooks-sdk/settings ->
+#            Trusted Publishing. No token.
 #   npm    — trusted publishing (OIDC): configure a trusted publisher
 #            on the package (repo responsibleai/agent-hooks, workflow
 #            release.yml, environment release) at
@@ -20,7 +23,12 @@
 #            trusted publishing — bootstrap once with a granular token
 #            (npm publish from a maintainer machine or a temporary
 #            NPM_TOKEN secret), then configure the publisher.
-#   NuGet  — secret NUGET_API_KEY (scoped to ResponsibleAI.AgentHooks).
+#   NuGet  — trusted publishing (OIDC): configure a Trusted Publishing
+#            policy on nuget.org (repo responsibleai/agent-hooks,
+#            workflow release.yml, environment release); the NuGet/login
+#            action exchanges the workflow OIDC token for a short-lived
+#            key. Set the non-sensitive NUGET_USER secret to the
+#            nuget.org username that owns the policy.
 #   Go     — no registry: the module proxy serves the git tag directly.
 name: release
 
@@ -98,12 +106,16 @@ jobs:
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2
         with:
           subject-path: sdk/rust/target/package/*.crate
+      - name: Authenticate to crates.io (trusted publishing)
+        if: env.DRY_RUN != 'true'
+        id: cratesio-auth
+        uses: rust-lang/crates-io-auth-action@e919bc7605cde86df457cf5b93c5e103838bd879 # v1
       - name: Publish to crates.io
         if: env.DRY_RUN != 'true'
-        run: cargo publish --locked -p agent-hooks-sdk --token "$CARGO_REGISTRY_TOKEN"
+        run: cargo publish --locked -p agent-hooks-sdk
         working-directory: sdk/rust
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.cratesio-auth.outputs.token }}
 
   typescript:
     runs-on: ubuntu-latest
@@ -172,12 +184,16 @@ jobs:
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2
         with:
           subject-path: sdk/dotnet/dist/*.nupkg
+      - name: Authenticate to NuGet (trusted publishing)
+        if: env.DRY_RUN != 'true'
+        id: nuget-login
+        uses: NuGet/login@d2e63aec27eb60a1d40f4c1c9440059cbf27d19a # v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Publish to NuGet
         if: env.DRY_RUN != 'true'
-        run: dotnet nuget push dist/*.nupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push dist/*.nupkg --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json
         working-directory: sdk/dotnet
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
   # Go has no upload: the module proxy serves the tag. This job proves
   # the tagged tree builds as a module consumer would see it.


### PR DESCRIPTION
Replaces the last two long-lived registry secrets. crates.io authenticates via `rust-lang/crates-io-auth-action` (OIDC exchanged for a short-lived token) and NuGet via `NuGet/login` (OIDC exchanged for a temporary key under a Trusted Publishing policy). With PyPI and npm already on OIDC, all four registries are tokenless; the `release` environment and its `v*` tag policy bound the publishing identity.