### PR TITLE
docs+governance: runbooks, controls mapping, interop, proposals process, native deployment

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -75,3 +75,12 @@ abi3 stable ABI (Python) and napi (Node) minimize the matrix. Go via cgo
 loses `CGO_ENABLED=0` cross-compilation and pure-static binaries; hosts
 that require pure-Go should vendor the golden vectors and treat the Rust
 core as the reference oracle. This is documented, not hidden.
+Per-OS deployment of the native artefact is covered in each SDK's
+README ("Native library deployment").
+
+## Design decisions
+
+Contract-level decisions are made through written proposals under
+[`docs/proposals/`](docs/proposals/README.md) (P-001..P-004 to date:
+verdict algebra, composition profiles, identity provider seam). The
+proposal README defines which change classes require one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+User-visible changes to the spec and SDKs. Versioning rules:
+[VERSIONING.md](VERSIONING.md).
+
+## 0.1.0-alpha.2 — unreleased (pending tag `v0.1.0-alpha.2`)
+
+Contract redesign relative to alpha.1 (breaking; the spec remains
+`agent-hooks/0.1` — pre-release drafts within the 0.1 window are not
+compatibility-bound until the first spec tag):
+
+- **Three-verdict model** (P-003): `allow` / `deny` / `transform`.
+  `warn` became `allow` + `warnings[]`; `escalate` became a **liftable
+  deny** (`deny` + `approval` block) — fail-closed by construction.
+- **Composition profiles** (P-003): host-declared, closed set —
+  `sequential/first_deny` (`on_approval: stop|resume`),
+  `sequential/run_all`, `parallel/strictest`, `parallel/unanimous` —
+  recorded on every emission; fixed severity order; §7.3 warning/label
+  unions.
+- **Identity provider seam** (P-004): `jcs-sha256` default (RFC 8785 +
+  SHA-256, fail-closed I-JSON domain), custom or `null` permitted
+  under echo + record rules; JCS serializer vendored into the core.
+- **InterceptionRecord**: payload-free verdict projection
+  (`transform.value` dropped, messages truncated), `composition`
+  block, `verdicts[]` summary, `decided_by`, `fold_truncated`,
+  `resolved_by`, `identity_provider`; record sink + drop-oldest
+  retention with `records_dropped`.
+- **Approval seam**: escalation-time identity binding, byte-exact echo
+  rule, redaction seam (request identity computed over the redacted
+  context), resolver-less liftable denies stand without error.
+- **Value domain** (§4.4): reject-never-normalize; big-integer
+  rejection beyond ±(2⁵³−1) including raw-literal scan beyond u64;
+  NaN/surrogate marshalling guards in every SDK.
+- **Enforcement hardening**: `catch_unwind` on the entire C ABI,
+  Go panic recovery, Rust panic isolation + opt-in `tokio-timeout`,
+  nesting-depth caps, 10240-byte evidence cap, streaming-egress rule
+  (§12.1a) with the `buffered_output` capability.
+- **Conformance**: 36+ vectors with per-part reporting (tiers
+  removed), golden identity fixtures, declared-surface claims.
+- **Distribution**: per-SDK READMEs with trust-model statements;
+  tag-driven release pipeline with SBOM + provenance; OIDC trusted
+  publishing on all four registries; supply-chain pinning
+  (`--locked`, lockfiles, pinned actions, Dependabot).
+
+## 0.1.0-alpha.1 — 2026-07-08 (superseded)
+
+Initial extraction from the Agent Control Specification: eight
+interception points, five-verdict draft contract, tiered
+`AgentContext`, RFC 8785 identity, initial CTK. Published to PyPI
+(`agent-hooks-sdk 0.1.0a1`) and crates.io
+(`agent-hooks-sdk 0.1.0-alpha.1`); both implement the superseded
+draft — do not use (see SECURITY.md supported versions).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+## Ground rules
+
+- **Sign-off (DCO).** Every commit carries `Signed-off-by`
+  (`git commit -s`), certifying the
+  [Developer Certificate of Origin](https://developercertificate.org/).
+- **Proposals first** for contract-level changes: see
+  [docs/proposals/README.md](docs/proposals/README.md) for the change
+  classes that require a written proposal before implementation.
+- **Everything lands by PR.** `main` is protected: required status
+  checks across all five SDKs plus schema-drift and CodeQL, linear
+  history (rebase merges), no force pushes.
+
+## What a PR must include
+
+- **Tests for behavior.** New or changed normative behavior needs CTK
+  vectors (`conformance/vectors/`) or per-SDK tests — cross-SDK
+  semantics belong in vectors so all five implementations are pinned
+  at once.
+- **Spec and schema together.** Changes to wire shapes update the spec
+  text, the JSON schemas under `spec/schema/`, and the vendored copies
+  (regenerate via `python3 scripts/gen-per-point-schemas.py`; the
+  `drift` check enforces this).
+- **All five SDKs.** A contract change is not done until Rust core,
+  Python, TypeScript, .NET, and Go agree; the Rust core is the single
+  source of truth and the wrappers delegate to it.
+
+## Local test matrix
+
+```bash
+# Rust core + FFI
+cd sdk/rust && cargo test --workspace --all-features && cargo clippy --workspace -- -D warnings
+# Python (rebuild bindings when core changed)
+cd sdk/python && maturin develop --release && python -m pytest tests/ && ruff check
+# TypeScript (rebuild native when core changed)
+cd sdk/typescript && npm ci && npm test
+# .NET (needs the FFI cdylib on the library path)
+cargo build --release --manifest-path sdk/rust/Cargo.toml -p agent-hooks-ffi
+cd sdk/dotnet && LD_LIBRARY_PATH=../rust/target/release dotnet test
+# Go
+cd sdk/go && CGO_ENABLED=1 go test ./...
+```
+
+## Style
+
+- Fail closed; never normalize values (§4.4 — reject with an
+  actionable message instead).
+- Spec-section references in doc comments (`§7.4`, `§10.3`).
+- Commit messages and PR bodies: concise, factual, imperative subject.
+
+## Reporting security issues
+
+Privately, per [SECURITY.md](SECURITY.md) — not via public issues.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,44 @@
+# Governance
+
+## Maintainers
+
+| Role | Who |
+| --- | --- |
+| Maintainer, decision authority | [@MohammadHaroonAbuomar](https://github.com/MohammadHaroonAbuomar) |
+
+The project is currently single-maintainer. A second code owner for
+`/spec/` and `/conformance/` is an open goal before external adapters
+file conformance claims; until then, single-maintainer decision-making
+is a documented limitation, not an implicit norm.
+
+## How decisions are made
+
+- **Design decisions** in the classes listed in
+  [docs/proposals/README.md](docs/proposals/README.md) require a
+  written proposal (P-NNN) decided by the maintainers. Everything else
+  is decided by ordinary PR review.
+- **Change gating:** `main` is protected — every change lands by PR
+  with all required status checks (build/test across the five SDKs,
+  schema drift, CodeQL) passing; linear history; no force pushes.
+  Review requirements follow `.github/CODEOWNERS`.
+- **Versioning and release:** rules in [VERSIONING.md](VERSIONING.md);
+  releases are tag-driven through the release workflow (provenance
+  attestation, SBOM, OIDC trusted publishing). User-visible changes
+  are recorded in [CHANGELOG.md](CHANGELOG.md).
+- **Conformance claims** from third parties are accepted per the
+  process in [conformance/CLAIMS.md](conformance/CLAIMS.md).
+
+## Security response
+
+Vulnerabilities are reported privately per [SECURITY.md](SECURITY.md)
+(GitHub security advisories; acknowledgment target three business
+days). Security fixes may bypass the proposal review window but not
+the required status checks.
+
+## Succession
+
+If the maintainer becomes unavailable, ownership transfers within the
+`responsibleai` GitHub organization; the organization owners hold
+administrative access to the repository and the registry publishing
+configurations (all registries use OIDC trusted publishing bound to
+this repository, so no personal tokens need transferring).

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ the normative statement.
 | [`conformance/HARNESS.md`](conformance/HARNESS.md) | How to write a harness for your framework |
 | [`sdk/python/`](sdk/python/) | Reference SDK: types + emitter + **complete CTK runner** |
 | [`sdk/{rust,typescript,dotnet,go}/`](sdk/) | Bindings over the Rust core: types, emitter, CTK runner, ReferenceHarness |
+| [`docs/PRODUCTION.md`](docs/PRODUCTION.md) / [`docs/OPERATIONS.md`](docs/OPERATIONS.md) | Production checklist and operations runbook for host operators |
+| [`docs/THREAT-MODEL.md`](docs/THREAT-MODEL.md) | Threat catalog with mitigation→verification traceability |
+| [`docs/CONTROLS-MAPPING.md`](docs/CONTROLS-MAPPING.md) / [`docs/INTEROP.md`](docs/INTEROP.md) | OWASP/NIST mapping; MCP and A2A interop guidance |
+| [`docs/proposals/`](docs/proposals/) | Design proposals (process in [`docs/proposals/README.md`](docs/proposals/README.md)) |
+| [`GOVERNANCE.md`](GOVERNANCE.md) / [`CONTRIBUTING.md`](CONTRIBUTING.md) / [`CHANGELOG.md`](CHANGELOG.md) | Project governance, contribution rules, change history |
 
 ## The contract in one diagram
 
@@ -77,6 +82,10 @@ and [`conformance/HARNESS.md`](conformance/HARNESS.md).
 
 **Interceptor:** implement `Interceptor.intercept(AgentContext) -> Verdict`
 in any SDK; register with the host.
+
+**Running it in production:** read [`docs/PRODUCTION.md`](docs/PRODUCTION.md)
+(the decisions to make consciously) and [`docs/OPERATIONS.md`](docs/OPERATIONS.md)
+(failure reasons, rollout, alerting) first.
 
 **Prove conformance:**
 

--- a/conformance/CLAIMS.md
+++ b/conformance/CLAIMS.md
@@ -29,6 +29,30 @@ retract already-streamed content (§12.1a).
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | reference-agent | 0.1.0 | agent-hooks/0.1 | model_calls, tool_calls, int64_json (not typescript) | all four (§7.2), all knobs | jcs-sha256 (+ null, vector-scoped) | python, typescript, dotnet, go, rust | (CI: CTK self-test, all parts) | In-tree reference |
 
-To file a claim, open a PR adding a row with a link to a passing CTK
-run, and confirm in the PR description that the harness drives the
-framework's production dispatch path with only model/tool I/O mocked.
+## Filing and acceptance
+
+A claim is filed as a PR adding one row to the table above. Required
+artefacts, in the PR:
+
+1. **The per-part CTK report** (runner output grouped by `part`) from
+   a run against the claimed adapter version, linked or attached —
+   100% pass on the declared surface, skips only from undeclared
+   capabilities.
+2. **Harness description**: which SDK runner, and how the harness
+   wires the framework — specifically confirming it drives the
+   framework's **production dispatch path** with only model/tool I/O
+   mocked (a harness that re-implements dispatch attests nothing).
+3. **Disclosure flags** where applicable: `identity_provider: null` →
+   the claim states records/approvals are identity-unbound;
+   custom provider → content-derived or not; `buffered_output: false`
+   → the claim states a deny at `output` cannot retract streamed
+   content.
+
+Acceptance is by CODEOWNERS review (`conformance/` owner). The
+reviewer checks: the report matches the declared surface tuple; the
+report's vector inventory matches the spec version claimed; the
+production-path confirmation is present; disclosure flags are
+consistent. Where the adapter is open source, the reviewer MAY re-run
+the CTK before accepting. Acceptance records the claim; it is not an
+endorsement, and rows may be removed if a claim is later found not to
+reproduce.

--- a/docs/CONTROLS-MAPPING.md
+++ b/docs/CONTROLS-MAPPING.md
@@ -1,0 +1,49 @@
+# Controls mapping (informative)
+
+How agent-hooks mechanisms map onto external control frameworks:
+OWASP LLM Top 10 (2025) and the NIST AI Risk Management Framework.
+Threat rows (`TM-NN`) reference [THREAT-MODEL.md](THREAT-MODEL.md) so
+this mapping and the threat model stay in sync.
+
+> **Not a certification.** agent-hooks is a cooperative contract, not
+> a security boundary (spec §1.4), and a conformance claim is not a
+> security certification (`conformance/CLAIMS.md`). The mechanisms
+> below *support* the listed controls when a host wires them and
+> registers appropriate interceptors; they do not by themselves
+> satisfy any framework requirement.
+
+## OWASP LLM Top 10 (2025)
+
+| OWASP | Supporting mechanism | Threat rows |
+| --- | --- | --- |
+| LLM01 Prompt Injection | `input` / `pre_model_call` interception: interceptors `deny` or `transform` untrusted content before it reaches the model; `pre_tool_call` gates the resulting actions (§3, §6) | TM-01 |
+| LLM02 Sensitive Information Disclosure | `output` / `post_model_call` / `post_tool_call` interception for egress filtering; payload-free records (§10.3); approval-channel redaction seam (§9); `result_labels` flow tracking (§5.4) | TM-09, TM-13, TM-22 |
+| LLM03 Supply Chain | Not a runtime mechanism — the project's own posture: pinned actions, committed lockfiles with `--locked` CI, SBOM + provenance attestation in the release pipeline, OIDC trusted publishing | TM-14 |
+| LLM04 Data and Model Poisoning | Partial: `post_tool_call` interception can filter retrieved/tool-supplied content before it enters agent state (§6.1); training-time poisoning is out of scope | TM-01 |
+| LLM05 Improper Output Handling | `output` interception with transform/deny before the response reaches the caller; §12.1a buffering rule for streamed output | TM-11 |
+| LLM06 Excessive Agency | `pre_tool_call` deny/transform per call; liftable denies routing high-impact actions through the human approval seam (§5.1, §9); composition profiles determining which controls evaluate (§7) | TM-01, TM-18, TM-19, TM-20 |
+| LLM07 System Prompt Leakage | Partial: `pre_model_call` exposes the full message chain to interceptors for outbound inspection; `output` filtering for leak detection | TM-01 |
+| LLM08 Vector and Embedding Weaknesses | Out of scope: agent-hooks does not mediate retrieval internals; a host may surface retrieval as a tool, gaining `pre/post_tool_call` coverage | — |
+| LLM09 Misinformation | Partial: `output`/`post_model_call` interceptors may annotate via `warnings`/`result_labels`; content verification itself is an interceptor concern | TM-13 |
+| LLM10 Unbounded Consumption | Payload bounds with a normative fail-closed breach rule (§12.3); interceptor timeouts (§7); the optional `budgets.*` context fields give interceptors the data to enforce quota policy | TM-12 |
+
+## NIST AI RMF
+
+Mapping at the function level, with the subcategories the record
+mechanism most directly supports. agent-hooks is a *runtime control
+and evidence* layer: it contributes primarily to MANAGE and to the
+measurement half of MEASURE.
+
+| RMF function | Contribution |
+| --- | --- |
+| GOVERN | Governance artefacts for the contract itself (GOVERNANCE.md, proposals process, VERSIONING.md); the conformance-claim discipline (§13.3, CLAIMS.md) gives adopters a documented basis for third-party assertions |
+| MAP | The eight interception points (§3) enumerate exactly where an agent system's autonomous actions can be observed and controlled — a concrete map of the runtime decision surface |
+| MEASURE | InterceptionRecords: payload-free, totally ordered per session, attributable (`decided_by`), tamper-evident under a content-derived identity provider (§10); `evaluate_only` mode measures would-be enforcement before it is enabled (§8) |
+| MANAGE | Enforcement itself: fail-closed deny/transform obligations (§6), human-in-the-loop escalation via liftable denies (§9), composition profiles for defense-in-depth (§7), staged rollout path (`evaluate_only` → `enforce`, see OPERATIONS.md) |
+
+**Logging-obligation note.** The record shape (§10.3) — ordered,
+attributable, payload-free, identity-bound — is designed to *support*
+regulatory logging obligations (e.g. EU AI Act record-keeping for
+high-risk systems) without storing payloads; whether a given
+deployment satisfies any obligation depends on the host's retention,
+protection, and completeness, which this contract does not control.

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -1,0 +1,78 @@
+# Ecosystem interop (informative)
+
+How agent-hooks maps onto the protocols agent frameworks actually
+speak. agent-hooks is deliberately protocol-neutral: it intercepts a
+host's agent loop, not the wire. This appendix shows the canonical
+correspondences so adapters agree on them instead of re-deriving them.
+
+## MCP (Model Context Protocol)
+
+An MCP **client** (the agent host) invoking tools on MCP servers is
+the exact surface `pre_tool_call`/`post_tool_call` mediates. The
+canonical field mapping:
+
+### `tools/call` request → `pre_tool_call` context
+
+| MCP | AgentContext (§4.2) |
+| --- | --- |
+| request `id` (JSON-RPC) | `tool_call.id` |
+| `params.name` | `tool_call.name` |
+| `params.arguments` | `tool_call.args` — also the `target`, so a `transform` rewrites the arguments actually sent (§4.3) |
+
+A combined `deny` means the host MUST NOT send the `tools/call`
+request (§6); surface a tool error to the model per §6.2.
+
+### `tools/call` result → `post_tool_call` context
+
+| MCP | AgentContext (§4.2) |
+| --- | --- |
+| result `content` | `tool_result.value` — the `target`; a `transform` rewrites what enters agent state |
+| result `isError` | `tool_result.is_error` |
+| (request echo) | `tool_call.{id,name,args}` MUST reflect the arguments actually sent, i.e. post-transform (§4.2) |
+
+A combined `deny` at `post_tool_call` discards the result as if it
+had errored (§6.1); the host MUST NOT re-invoke the tool.
+
+Notes:
+
+- Multi-part MCP `content` arrays pass through as the JSON value they
+  are; the contract does not flatten them.
+- 64-bit identifiers inside `arguments` are subject to the §4.4 value
+  domain — string-encode at the adapter boundary.
+- MCP resource reads and prompt gets are not tool calls; a host that
+  wants them mediated surfaces them as tools (gaining
+  `pre/post_tool_call` coverage) or treats fetched content as `input`.
+- MCP **sampling** (`sampling/createMessage`, server-initiated model
+  calls through the client) is a model call in the host's loop:
+  bracket it with `pre_model_call`/`post_model_call`.
+
+## MCP elicitation and the approval seam
+
+MCP **elicitation** (a server asking the user for input mid-call) and
+agent-hooks **escalation** solve adjacent problems and compose rather
+than compete:
+
+- An agent-hooks liftable deny (§5.1) consults the host's approval
+  resolver (§9). A host whose UI stack is MCP-native MAY implement
+  that resolver *via* an elicitation round-trip to the user — the
+  elicitation is the resolver's transport, not a separate verdict
+  path.
+- The §9 rules still bind: the request carries the context identity
+  (computed over the redacted context the approver sees), the
+  resolution echoes it byte-for-byte, and `approve` carries a permit
+  verdict. An elicitation answer maps to
+  `approve`/`reject`/`unresolved` at the adapter.
+- Server-initiated elicitation for the tool's own parameters (a form,
+  a confirmation) is ordinary tool behaviour and needs no agent-hooks
+  involvement.
+
+## A2A (agent-to-agent) delegation
+
+From the delegating agent's perspective, sending a task to another
+agent is an outbound action: bracket it as a tool call
+(`pre_tool_call`/`post_tool_call` with the A2A task as `args`/
+`tool_result`). The remote agent's own loop — if it also implements
+agent-hooks — is a separate session with its own `agent_startup`,
+records, and identities; the contract defines no cross-session
+identity propagation today (the `trace.*` optional fields, §4.5,
+carry W3C Trace Context for correlation).

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,73 @@
+# Operations runbook
+
+Day-2 guidance for hosts running agent-hooks in production: what each
+fail-closed reason means, how to roll out, and what to alert on.
+Companion to the [production checklist](PRODUCTION.md). This document
+is informative; the reason inventory is normative in
+[spec §11](../spec/AGENT-HOOKS-0.1.md#11-reserved-reasons)
+(machine-readable: `spec/reserved-reasons.json`).
+
+## 1. Failure reasons: cause → remediation
+
+Every host-synthesized deny carries a reserved `host_error:*` reason.
+The contract is fail-closed: these denies halt the guarded action, so
+a persistent failure is an agent outage by design, not a bug in the
+contract.
+
+| Reason | Likely cause | Remediation |
+| --- | --- | --- |
+| `context_invalid` | Host adapter built a schema-invalid context; value outside the I-JSON domain (integer beyond ±(2⁵³−1), non-finite float, lone surrogate); depth/size bound breached | Fix the adapter's context construction; string-encode 64-bit identifiers (§4.4); check the deny message — remediation detail names the path and constraint |
+| `interceptor_failed` | Interceptor raised/panicked or returned a non-JSON value | Fix the interceptor; the record's `decided_by` names its registration index; message carries the exception type only |
+| `interceptor_timeout` | Interceptor exceeded the configured timeout (default 5000 ms) | Check interceptor latency (downstream policy service?); prefer async interceptors; tune the timeout deliberately |
+| `verdict_invalid` | Verdict failed §5 validation: unknown decision, `warn`/`escalate` wire values (removed), `approval` on a permit, reserved reason, malformed `warnings`, `evidence` over 10240 bytes | Migrate the interceptor to the three-verdict model (`Verdict.warn`/`Verdict.escalate` SDK sugar emits the correct shapes); shrink evidence to a pointer |
+| `transform_invalid` | `transform.path` did not resolve against the target | Fix the interceptor's path or guard on target shape |
+| `transform_target_forbidden` | Path not rooted at `$target`, or transform at `agent_startup`/`agent_shutdown` | Fix the interceptor; those points define no mutable target (§4.3) |
+| `transform_conflict` | Two-plus transforms against the same snapshot in a parallel profile (§7.5) | Expected under `parallel/strictest` with multiple transformers: pick the `on_transform_conflict` knob (`deny` or `approval`) consciously, or use a sequential profile where transforms fold |
+| `composition_disagreement` | Non-unanimous outcome under `parallel/unanimous` (§7.5) | Expected; tune `on_disagreement` or switch profile if too strict |
+| `approval_resolver_failed` | Resolver (or the approval redactor) raised or timed out | Check resolver/approval-channel health; a liftable deny with **no registered resolver** is NOT an error — the deny simply stands |
+| `approval_unresolved` | Resolver returned `unresolved` | Approval channel could not decide (UI timeout, queue overflow); investigate resolver-side |
+| `approval_identity_mismatch` | Resolution's `context_identity` violated the echo rule (§9) | Resolver must echo the request identity byte-for-byte (null echoes as null); indicates a broken or suspicious resolver |
+| `adapter_unsupported` | Host adapter cannot emit this interception point | Declare the capability subset honestly (§3.2) instead of synthesizing failures |
+| `no_interceptor` | `enforce`-mode emission with zero registered interceptors (§7) | Register controls, or an explicit allow-all interceptor for a deliberate passthrough |
+| `streaming_unsupported` | Host could not assemble a streamed model response before `post_model_call` (§12.1) | Buffer the stream or disable streaming on the model client |
+
+## 2. Rollout: `evaluate_only` → `enforce`
+
+1. **Shadow (evaluate_only).** Register production interceptors,
+   `evaluate_only` mode: every action proceeds; verdicts and records
+   are produced. Never report this state as enforcement (§8).
+2. **Analyze.** Measure would-be-deny rate by `reason` and
+   `decided_by`; fix adapter-caused `host_error:*` noise (these become
+   outages under enforce); validate approval-channel latency.
+3. **Enforce, staged.** Switch mode per session or per interception
+   point (§8) — e.g. `pre_tool_call` first, `output` last. Keep the
+   analysis dashboards; the same signals now measure halted actions.
+4. **Rollback is mode, not removal.** Dropping back to
+   `evaluate_only` preserves records and labels; unregistering
+   interceptors silently narrows the control plane (and zero
+   registered fails closed, §7).
+
+## 3. Alerting
+
+| Signal | Source | Why |
+| --- | --- | --- |
+| Fail-closed rate by `reason` | records: `verdict.reason` prefix `host_error:` | Infrastructure failures masquerade as policy denies; `interceptor_timeout`/`interceptor_failed` spikes are outages |
+| `fold_truncated: true` rate | records | Every occurrence means registered controls were skipped after an approval under `first_deny`+`stop` (§7.4) — confirm the skip pattern matches your registration-order design |
+| `resolved_by: "approval"` rate | records | Human-approval lift volume; a jump means controls are escalating more (or an automated resolver is lifting more) |
+| `records_dropped > 0` | emitter counter | Audit loss: the drop-oldest ring overflowed before the sink drained it — resize retention or fix the sink |
+| Record-sink failures | host sink wrapper | Sink exceptions are swallowed by design (audit must not alter control flow) — instrument the sink itself |
+| `approval_unresolved` / `approval_identity_mismatch` | records | Broken approval channel; mismatch may indicate a misbehaving resolver |
+| Sequence gaps within a session | records: `sequence` | Records are totally ordered per session (§12.2); a gap means record loss between emitter and storage |
+
+## 4. Incident notes
+
+- **A single failing interceptor halts the agent.** That is the
+  contract working (§1.3). Identify it via `decided_by` + `reason`,
+  fix or roll back *the interceptor*; use `evaluate_only` as a
+  last-resort bypass with explicit sign-off — never silently.
+- **Approval outage:** liftable denies stand as denies (fail-closed);
+  agents keep running but escalation-gated actions halt. No
+  contract-side action needed; restore the resolver.
+- **Suspected record tampering or drift:** `input_identity` /
+  `enforced_identity` under a content-derived provider re-bind each
+  record to the exact evaluated context; recompute to verify (§10).

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -1,0 +1,41 @@
+# Production checklist
+
+Deployment decisions a host operator must make consciously before
+running agent-hooks in production. Each row names the normative clause;
+the [operations runbook](OPERATIONS.md) covers day-2 concerns
+(monitoring, rollout, incident response). This document is informative.
+
+## Checklist
+
+| # | Decision | Guidance |
+| --- | --- | --- |
+| 1 | **Enforcement mode** | Run `enforce` in production. `evaluate_only` invokes interceptors and records verdicts but proceeds with every action; it MUST NOT be presented to any downstream system as enforcement (§8) — misreporting it is a compliance hazard, not a configuration choice. |
+| 2 | **Interceptor latency** | Fail-closed semantics turn a hung interceptor into a halted agent. Keep the RECOMMENDED 5000 ms timeout (§7) or tune it deliberately; prefer async interceptors — a synchronous interceptor that blocks the event loop cannot be interrupted by the timeout in Python/TypeScript. In Rust, timeout enforcement is opt-in (`tokio-timeout` feature) or host-owned. |
+| 3 | **Composition profile** | The default, `sequential/first_deny` with `on_approval: "stop"`, short-circuits: interceptors registered **after** an approved escalation never run for that emission (§14). The skip is recorded (`fold_truncated: true`), but coverage is your registration order. Choose per the table below; register must-run controls before escalation-capable ones. |
+| 4 | **Identity provider** | Keep the default `jcs-sha256` unless you have a concrete reason not to: it is what makes approvals content-bound and records correlatable. A `null` provider is conformant but identity-unbound — your conformance claim MUST say so (§10.1, §13.3). A custom provider must disclose whether it is content-derived. |
+| 5 | **Record persistence** | `InterceptionRecord`s are the audit trail and are payload-free by construction (§10.3). Configure a record sink; the in-memory buffer is drop-oldest with a `records_dropped` counter — alert on it (see OPERATIONS). Persist `result_labels` with produced data and resurface them per §5.4. |
+| 6 | **Approval-channel redaction** | The `ApprovalRequest` carries the context as presented to the resolver and MAY be redacted (§9). Use the emitter's approval-redactor seam; the request identity is computed over the *redacted* context, so the binding covers exactly what the approver saw. Document redaction in `extensions.<host>.redacted`. |
+| 7 | **Payload bounds** | Contexts are canonicalized, hashed, and deep-copied per interceptor per emission. Apply the RECOMMENDED bounds (5 MiB serialized, depth 128, §12.3); whatever limit you enforce, breach MUST yield `deny host_error:context_invalid`, never a crash or truncation. |
+| 8 | **Output streaming** | If you stream output to the caller, buffer until the `output` combined verdict permits (§12.1a) — or declare `buffered_output: false` and state in your claim that a deny at `output` cannot retract streamed content. |
+| 9 | **Value domain** | String-encode 64-bit identifiers at the adapter boundary (§4.4). JavaScript hosts cannot observe big integers at all (`JSON.parse` rounds first); Go hosts must decode with `json.Number`. |
+| 10 | **Zero-interceptor state** | An `enforce`-mode emission with nothing registered fails closed (`host_error:no_interceptor`, §7). A deliberate passthrough is an explicit allow-all interceptor — deploy one consciously or not at all. |
+
+## Profile selection
+
+| Requirement | Profile | Notes |
+| --- | --- | --- |
+| Lowest latency; first deny ends the emission | `sequential/first_deny`, `on_approval: "stop"` (default) | Interceptors after an approved escalation are skipped (`fold_truncated`); order controls accordingly (§14) |
+| Approval lifts a deny but later controls still run | `sequential/first_deny`, `on_approval: "resume"` | Multiple consultations possible, bounded by interceptor count (§7.4) |
+| Every control evaluates every emission | `sequential/run_all` | Severity-max aggregate; at most one consultation, and only when **every** deny is liftable (§7.4) |
+| Independent verdicts over one snapshot; no transform chaining | `parallel/strictest` | Concurrent transforms conflict (`on_transform_conflict` knob, §7.5) |
+| Anything but unanimous allow blocks | `parallel/unanimous` | Disagreement handling per `on_disagreement` knob (§7.5) |
+
+A sequential interceptor can blind its successors via transform;
+parallel profiles remove that vector at the cost of transform
+composition (§14).
+
+## Related
+
+- [OPERATIONS.md](OPERATIONS.md) — runbook: failure reasons, rollout, alerting
+- [THREAT-MODEL.md](THREAT-MODEL.md) — what the contract does and does not defend against
+- [spec §14](../spec/AGENT-HOOKS-0.1.md#14-security-considerations) — normative security considerations

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -1,8 +1,9 @@
 # Threat model
 
-> **Status:** Draft, refreshed 2026-07-11 against the P-003/P-004
+> **Status:** Draft, refreshed 2026-07-15 against the P-003/P-004
 > contract (three-verdict model, composition profiles, identity
-> provider seam). Companion to [`SECURITY.md`](../SECURITY.md) and
+> provider seam) including the approval-redaction and record-sink
+> mechanisms. Companion to [`SECURITY.md`](../SECURITY.md) and
 > [spec §1.4](../spec/AGENT-HOOKS-0.1.md#14-trust-model-and-non-goals).
 > Every threat row names its mitigation (spec clause) and how that
 > mitigation is verified today. Rows marked **GAP** are known-untested;
@@ -64,6 +65,8 @@ SDKs; **GAP** = no automated verification exists.
 | TM-19 | Control skipping after approval: under `sequential/first_deny` + `on_approval: "stop"`, interceptors after the escalating one never run for that emission | E | In | §7.4: the skip is never silent — `fold_truncated: true` + `resolved_by: "approval"` MUST appear on the record; §14 RECOMMENDS registering must-run controls before escalation-capable ones; `run_all`/parallel profiles avoid the skip structurally | AH-CTK-030 (asserts `fold_truncated`/`resolved_by`), AH-CTK-080 (resume variant). Residual (accepted for 0.1, P-003): a must-run control needing *post-transform* context cannot be ordered before an escalating interceptor |
 | TM-20 | Synthesized-deny approval routing: with `on_transform_conflict`/`on_disagreement: "approval"`, the host manufactures a liftable deny (`decided_by: null`) and a resolver — possibly automated — can lift a conflict no interceptor chose to permit | E, T | In | §7.5: synthesis policies are host configuration from a closed set; the synthesized deny crosses the same §9 seam (echo rule, §5 gate on the resolution); reason is a reserved `host_error:*` string so the approver sees it is host-synthesized | AH-CTK-085/086 (conflict, both knobs), AH-CTK-087/088 (disagreement, both knobs) |
 | TM-21 | Control-plane crash as denial of service: malformed or adversarial content panics the core and kills the host process through the C ABI, or a panicking interceptor kills a Go host | D | In | Every `ah_*` entry point runs under `catch_unwind` (panic → error result, process survives); marshalling failures are explicit errors, never silent coercions; Go emitter `recover()`s interceptor/resolver panics into §6.3 denies | `sdk/rust/ffi/src/lib.rs` tests (invalid UTF-8, null pointer, big-int through the ABI); `sdk/go/agenthooks/emitter_test.go` panic tests |
+| TM-22 | Approval-channel payload exposure: the `ApprovalRequest` ships the full context to the resolver (and its UI/transport) by default, and a broken redactor could leak or bind the approval to content the approver never saw | I | In | §9: `request.context` MAY be redacted; the emitter redaction seam computes the request identity over the **redacted** context, so the echo-rule binding covers exactly what the approver saw; a raising/panicking redactor fails closed (`host_error:approval_resolver_failed`) | AH-CTK-099 (redaction + recomputed echo) + per-SDK seam tests. Residual: redaction policy content is host-defined; `extensions.<host>.redacted` disclosure is a SHOULD (§14) |
+| TM-23 | Audit-record loss: retention overflow or a failing record sink silently truncates the trail the payload-free design exists to preserve | R | In | Emitter retention is drop-oldest with a monotonic `records_dropped` counter (never silent); sink callback failures are swallowed **by design** — audit transport must not alter control flow (§6) — so sink health is a host monitoring obligation; `sequence` totality (§12.2) makes any loss detectable downstream | Per-SDK sink/retention tests (PR2 suite). Residual: a host that neither drains the sink nor watches `records_dropped` loses records knowingly — alerting guidance in docs/OPERATIONS.md §3 |
 
 ## 3. Out of scope
 

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,54 @@
+# Design proposals
+
+Significant design decisions are made through written proposals in
+this directory (P-001 through P-004 to date). This file defines when a
+proposal is required, its lifecycle, and who decides.
+
+## When a proposal is required
+
+Any change in these classes MUST go through a proposal before
+implementation:
+
+- anything `VERSIONING.md` classes as **spec MAJOR**: changes to
+  required/conditional context fields, the interception-point set,
+  verdict shape, composition semantics, or failure (fail-closed)
+  semantics;
+- adding, removing, or changing **composition profiles**, their knobs,
+  or their defaults (§7.2);
+- changes to the **identity** or **record** shape (§10) or to what a
+  conformance claim asserts (§13.3);
+- changes to the **trust model or non-goals** (§1.4).
+
+Additive optional/namespaced fields, new vectors, editorial spec
+changes, SDK-internal refactors, and CI/tooling changes do not require
+a proposal — ordinary PR review applies (see
+[CONTRIBUTING.md](../../CONTRIBUTING.md)).
+
+## Lifecycle
+
+`Draft` → `Decided` → (possibly) `Superseded`.
+
+- **Draft.** File `P-NNN-<slug>.md` following the structure of the
+  existing proposals: Status, Raised by, the gap, enumerated options
+  with trade-offs, a recommendation. Neutral framing of alternatives
+  is expected — P-001/P-002 were debated by independent per-option
+  advocates before decision, a practice worth keeping for contested
+  questions.
+- **Decided.** The Status line records the date, the decision, and any
+  amendments. Implementation follows the decision, not the other way
+  around; the deciding PR links the proposal.
+- **Superseded.** A later proposal that replaces a decision marks the
+  old one `Superseded by P-NNN` and states what survives (see
+  P-001/P-002 for the pattern).
+
+Decisions may be reopened only by a new proposal that names the
+evidence that changed (e.g. P-003's fold-resume reservation lists the
+specific field-frequency evidence that would reopen it).
+
+## Decision authority and review window
+
+Decision authority rests with the maintainers listed in
+[GOVERNANCE.md](../../GOVERNANCE.md). While the repository is private
+and pre-1.0 there is no minimum comment window; once public, proposals
+in the MUST classes above stay open for review at least **7 days**
+before a decision is recorded (security fixes exempt).

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -41,3 +41,32 @@ if (!record.Proceeds) return ToolError(record.Verdict.Reason);
 `Verdict.Warn(..)` / `Verdict.Escalate(..)` are the §5 constructor
 shortcuts. Run the conformance tests with
 `LD_LIBRARY_PATH=../rust/target/release dotnet test`.
+
+## Native library deployment
+
+`ResponsibleAI.AgentHooks` P/Invokes `libagent_hooks_ffi`; the current
+NuGet package does **not** bundle it. Build it once per target platform
+(`cargo build --release -p agent-hooks-ffi` under `sdk/rust`) and make
+it resolvable at process start:
+
+| OS | Artifact | Resolution |
+| --- | --- | --- |
+| Linux | `libagent_hooks_ffi.so` | `LD_LIBRARY_PATH`, or place next to the app binary |
+| macOS | `libagent_hooks_ffi.dylib` | `DYLD_LIBRARY_PATH`, or next to the app binary |
+| Windows | `agent_hooks_ffi.dll` | `PATH`, or next to the app binary |
+
+For self-contained deployment, ship the library app-local using the
+standard RID layout — add to your **application** csproj:
+
+```xml
+<ItemGroup>
+  <None Include="path/to/libagent_hooks_ffi.so"
+        Link="runtimes/linux-x64/native/libagent_hooks_ffi.so"
+        CopyToOutputDirectory="PreserveNewest" />
+</ItemGroup>
+```
+
+A missing library fails at first native call with `DllNotFoundException`
+naming `agent_hooks_ffi` — it is a deployment error, not a package bug.
+Per-RID bundling inside the NuGet package (`runtimes/<rid>/native/`) is
+planned but not yet shipped.

--- a/sdk/dotnet/src/AgentHooks/AgentHooks.csproj
+++ b/sdk/dotnet/src/AgentHooks/AgentHooks.csproj
@@ -7,8 +7,10 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Native library resolved at runtime via NativeLibrary search paths.
-         Packaging: the release workflow bundles libagent_hooks_ffi per RID
-         under runtimes/<rid>/native/. For local dev, set
+         Packaging: the current NuGet package does NOT bundle
+         libagent_hooks_ffi; consumers make it resolvable per OS (see
+         README "Native library deployment"). Per-RID bundling under
+         runtimes/<rid>/native/ is planned. For local dev, set
          LD_LIBRARY_PATH / DYLD_LIBRARY_PATH / PATH to sdk/rust/target/release. -->
   </ItemGroup>
 </Project>

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -43,3 +43,27 @@ constructor shortcuts. Interceptor/resolver panics are recovered and
 fail closed (§6.3). **Value-domain note (spec §4.4):** decode JSON
 carrying 64-bit integers with `json.Number` — default `any`
 decoding rounds beyond 2^53 exactly like JavaScript.
+
+## Native library deployment
+
+The Go SDK links `libagent_hooks_ffi` via cgo. Build-time and run-time
+are separate concerns:
+
+```bash
+# Build time (compile + link)
+export CGO_ENABLED=1
+export CGO_LDFLAGS="-L/path/to/agent-hooks/sdk/rust/target/release -lagent_hooks_ffi"
+go build ./...
+
+# Run time (dynamic loader must find the library)
+# Linux:   export LD_LIBRARY_PATH=/path/to/sdk/rust/target/release
+# macOS:   export DYLD_LIBRARY_PATH=/path/to/sdk/rust/target/release
+# Windows: add the directory to PATH
+```
+
+To avoid the run-time variable on Linux, bake an rpath at link time:
+`CGO_LDFLAGS="-L... -lagent_hooks_ffi -Wl,-rpath,/opt/agent-hooks/lib"`.
+A missing library fails at process start with a loader error naming
+`libagent_hooks_ffi` — deployment, not code. Cross-compiling requires a
+Rust target + C toolchain for the same triple; build the cdylib with
+`cargo build --release --target <triple> -p agent-hooks-ffi` first.

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -45,3 +45,12 @@ feature; timeouts are host-owned (see the `emitter` module docs).
 
 Golden identity vectors pin byte-identical canonicalization across all
 five SDKs: `cargo test --workspace --all-features`.
+
+## Native artifact notes
+
+Rust hosts consume the `agent-hooks-sdk` crate directly — no dynamic
+library involved. The `ffi/` crate (cdylib `libagent_hooks_ffi`) exists
+for the other four SDKs; build it with
+`cargo build --release -p agent-hooks-ffi` when developing against
+Python/TypeScript/.NET/Go locally (their READMEs cover per-OS
+placement).

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -45,3 +45,13 @@ integers beyond 2^53 before any guard can run, so this SDK cannot claim
 the `int64_json`/`bigint_json` CTK capabilities — string-encode
 64-bit identifiers at the adapter boundary. Non-finite numbers are
 rejected fail-closed by a pre-serialization scan.
+
+## Native module deployment
+
+The npm package bundles the napi-rs native module (`*.node`) **for the
+platform it was built on** — the published alpha ships `linux-x64-gnu`
+only. On other platforms, install from source (needs a Rust toolchain):
+`npm run build` produces the module for your host platform. Per-platform
+`optionalDependencies` packages (the standard napi-rs multi-platform
+layout) are planned. A platform mismatch fails at `require` time with a
+module-load error naming the missing `.node` binary.


### PR DESCRIPTION
Documentation and governance follow-ups from the 2026-07-09 architectural review (docs-only).

- **PRODUCTION.md / OPERATIONS.md**: operator checklist (mode, timeouts, profile selection with the `first_deny`+`stop` ordering pitfall, identity provider, record persistence, redaction, bounds, streaming); runbook with the full `host_error:*` reason->cause->remediation table, staged `evaluate_only`->`enforce` rollout, and alerting signals (`fold_truncated`, `records_dropped`, sequence gaps).
- **CONTROLS-MAPPING.md / INTEROP.md**: OWASP LLM Top 10 (2025) + NIST AI RMF mapping reusing TM-NN rows, with the non-certification disclaimer; MCP `tools/call` <-> `pre/post_tool_call` field mapping, MCP elicitation as a §9 resolver transport, A2A note.
- **Governance**: `docs/proposals/README.md` (change classes requiring a proposal, lifecycle, authority, post-public 7-day window), `GOVERNANCE.md`, `CONTRIBUTING.md` (DCO), `CHANGELOG.md`; `CLAIMS.md` filing-and-acceptance process (required report, production-path attestation, disclosure flags, reviewer steps).
- **THREAT-MODEL**: +TM-22 (approval-redaction seam), +TM-23 (record retention/sink loss) — the two mechanisms shipped after the 07-11 refresh; TM-18..20 verified already present.
- **Native deployment**: per-OS sections in the dotnet/go/typescript/rust READMEs; `AgentHooks.csproj` comment aligned with actual packaging (no RID bundling shipped yet).

All markdown links verified; cited vectors/APIs/spec sections checked against HEAD.
