### PR TITLE
Formatter gates, cross-platform CI, benchmarks, allow-path copy elimination

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# Root editor defaults; language formatters (cargo fmt, ruff format,
+# dotnet format, gofmt) are authoritative and enforced in CI.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{rs,py}]
+indent_style = space
+indent_size = 4
+
+[*.{ts,mjs,js,json,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.cs]
+indent_style = space
+indent_size = 4
+
+[*.go]
+indent_style = tab
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/change-class.yml
+++ b/.github/workflows/change-class.yml
@@ -1,0 +1,54 @@
+# Change-class enforcement (GOVERNANCE.md).
+#
+# - PRs labeled `spec:breaking` must bump a version surface (the spec
+#   header or an SDK manifest) in the same PR.
+# - PRs that touch the normative surface (spec/, conformance vectors/
+#   schema) must carry one of the change-class labels so reviewers and
+#   the CHANGELOG see the classification.
+#
+# Required-check rule: this workflow has NO paths filter and reports on
+# every PR (a path-filtered required check deadlocks the queue — see
+# CONTRIBUTING.md).
+name: change-class
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  change-class:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Enforce label/version-bump coupling
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -eu
+          changed=$(git diff --name-only "$BASE"...HEAD)
+          echo "labels: ${LABELS:-<none>}"
+
+          normative=$(echo "$changed" | grep -E \
+            '^(spec/|conformance/vectors|conformance/vectors\.schema\.json)' || true)
+          if [ -n "$normative" ] && ! echo "$LABELS" | grep -qE 'spec:(breaking|additive)'; then
+            echo "::error::PR touches the normative surface but carries no spec:breaking/spec:additive label:"
+            echo "$normative"
+            exit 1
+          fi
+
+          if echo "$LABELS" | grep -q 'spec:breaking'; then
+            bump=$(echo "$changed" | grep -E \
+              '^(spec/AGENT-HOOKS|sdk/rust/core/Cargo\.toml|sdk/python/pyproject\.toml|sdk/typescript/package\.json|sdk/dotnet/src/AgentHooks/.*\.csproj|CHANGELOG\.md)' || true)
+            if [ -z "$bump" ]; then
+              echo "::error::spec:breaking PR must change a version surface (spec header, an SDK manifest, or CHANGELOG.md)"
+              exit 1
+            fi
+          fi
+          echo "change-class ok"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           uv pip install --system -r sdk/python/requirements-dev.lock
           uv pip install --system --no-deps --no-build-isolation -e ./sdk/python
-      - run: ruff check sdk/python
+      - run: ruff format --check sdk/python scripts && ruff check sdk/python scripts
       - run: pytest sdk/python/tests -p no:agent_hooks_ctk -v
 
   typescript:
@@ -69,6 +69,9 @@ jobs:
         working-directory: sdk/typescript
       - run: npm run build:native:debug
         working-directory: sdk/typescript
+      - name: Generated-binding drift (mirrors schema-drift)
+        run: git diff --exit-code -- binding.js binding.d.ts
+        working-directory: sdk/typescript
       - run: npx tsc
         working-directory: sdk/typescript
       # All test files, never an allowlist: the emitter suite shipped
@@ -82,7 +85,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
-        with: { components: clippy }
+        with: { components: "clippy, rustfmt" }
+      - run: cargo fmt --all --check
+        working-directory: sdk/rust
       - run: cargo clippy --locked --workspace --all-features -- -D warnings
         working-directory: sdk/rust
       - run: cargo test --locked --workspace --all-features
@@ -99,6 +104,8 @@ jobs:
       - uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with: { dotnet-version: "8.0.x" }
       - run: dotnet restore --locked-mode
+        working-directory: sdk/dotnet
+      - run: dotnet format --no-restore --verify-no-changes
         working-directory: sdk/dotnet
       - run: dotnet build --no-restore -warnaserror
         working-directory: sdk/dotnet
@@ -120,6 +127,7 @@ jobs:
         with: { go-version: "1.22" }
       - name: Build and test
         run: |
+          test -z "$(gofmt -l .)" || { gofmt -l .; echo "::error::gofmt violations"; exit 1; }
           go build ./...
           go vet ./...
           go test ./... -v
@@ -127,3 +135,42 @@ jobs:
         env:
           CGO_LDFLAGS: -L${{ github.workspace }}/sdk/rust/target/release -lagent_hooks_ffi
           LD_LIBRARY_PATH: ${{ github.workspace }}/sdk/rust/target/release
+
+  # Cross-platform build+test of the core and one FFI consumer
+  # (NEXT-23). Advisory: not in the required-check set yet — required
+  # names must be stable and always-reporting (see CONTRIBUTING.md).
+  rust-xplat:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - run: cargo test --locked --workspace --all-features
+        working-directory: sdk/rust
+
+  dotnet-xplat:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - name: Build ffi cdylib
+        run: cargo build --locked -p agent-hooks-ffi --release
+        working-directory: sdk/rust
+      - uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with: { dotnet-version: "8.0.x" }
+      - run: dotnet restore --locked-mode
+        working-directory: sdk/dotnet
+      - name: Test (native library via per-OS loader path)
+        run: dotnet test test/AgentHooks.Tests/ --nologo
+        working-directory: sdk/dotnet
+        env:
+          LD_LIBRARY_PATH: ${{ github.workspace }}/sdk/rust/target/release
+          DYLD_LIBRARY_PATH: ${{ github.workspace }}/sdk/rust/target/release
+          AGENT_HOOKS_FFI_DIR: ${{ github.workspace }}/sdk/rust/target/release

--- a/.gitignore
+++ b/.gitignore
@@ -459,3 +459,4 @@ sdk/go/**/*.test
 .vscode/
 .idea/
 .DS_Store
+.claude/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -80,6 +80,27 @@ byte-comparable across SDKs, so a divergence in any duplicated surface
 fails that SDK's self-test. (AH-CTK-104's `verdicts[]` assertions
 caught exactly such a drift during development.)
 
+## Latency budget
+
+The emitter sits on the critical path of every model and tool call.
+Budget (allow path, `sequential/first_deny`, jcs-sha256 provider, per
+emission, excluding interceptor bodies):
+
+| Context size | Interceptors | Budget |
+| --- | --- | --- |
+| ≤1 KiB | 1 | < 50 µs |
+| ≤100 KiB | 5 | < 2 ms |
+| ≤1 MiB | 10 | < 20 ms |
+
+Dominated by canonicalization+hash of the payload (once per emission on
+the allow path: `finalize` reuses the pre-dispatch identity when no
+transform folded). Verify with `cargo bench -p agent-hooks-sdk` —
+`benches/emission.rs` covers `context_identity`, `compose_aggregate`,
+and the full emit path at these sizes. Numbers are targets on
+commodity x86-64; CI does not gate on them (shared-runner variance
+makes threshold gates flaky) — regressions are caught by running the
+bench suite before release tags.
+
 ## Golden vectors
 
 `conformance/golden/identity.json` is generated from the Rust core by

--- a/scripts/gen-golden-identity.py
+++ b/scripts/gen-golden-identity.py
@@ -8,13 +8,16 @@ Expected outputs are computed by the Rust core via the Python FFI
 binding, so any language binding that agrees with these values agrees
 with Rust.
 """
+
 from __future__ import annotations
 
 import json
 import pathlib
 import sys
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "sdk" / "python" / "python"))
+sys.path.insert(
+    0, str(pathlib.Path(__file__).resolve().parents[1] / "sdk" / "python" / "python")
+)
 from agent_hooks import _core  # noqa: E402
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -38,112 +41,179 @@ FIXTURES: list[tuple[str, str, dict]] = [
     (
         "G-01-startup",
         "agent_startup baseline",
-        ctx("agent_startup", 0, {
-            "agent_init": {"tools_registered": ["a", "b"]},
-            "target": {"tools_registered": ["a", "b"]},
-        }),
+        ctx(
+            "agent_startup",
+            0,
+            {
+                "agent_init": {"tools_registered": ["a", "b"]},
+                "target": {"tools_registered": ["a", "b"]},
+            },
+        ),
     ),
     (
         "G-02-input-unicode",
         "input with non-ASCII content and emoji",
-        ctx("input", 1, {
-            "input": {"content": "héllo 🌍", "role": "user"},
-            "target": {"content": "héllo 🌍", "role": "user"},
-        }),
+        ctx(
+            "input",
+            1,
+            {
+                "input": {"content": "héllo 🌍", "role": "user"},
+                "target": {"content": "héllo 🌍", "role": "user"},
+            },
+        ),
     ),
     (
         "G-03-pre-tool-numbers",
         "pre_tool_call with number edge cases in args",
-        ctx("pre_tool_call", 4, {
-            "tool_call": {
-                "id": "tc-1", "name": "calc",
-                "args": {"i": 1, "f": 1.0, "neg0": -0.0, "big": 1e21,
-                         "small": 1e-7, "pi": 3.141592653589793},
+        ctx(
+            "pre_tool_call",
+            4,
+            {
+                "tool_call": {
+                    "id": "tc-1",
+                    "name": "calc",
+                    "args": {
+                        "i": 1,
+                        "f": 1.0,
+                        "neg0": -0.0,
+                        "big": 1e21,
+                        "small": 1e-7,
+                        "pi": 3.141592653589793,
+                    },
+                },
+                "target": {
+                    "i": 1,
+                    "f": 1.0,
+                    "neg0": -0.0,
+                    "big": 1e21,
+                    "small": 1e-7,
+                    "pi": 3.141592653589793,
+                },
             },
-            "target": {"i": 1, "f": 1.0, "neg0": -0.0, "big": 1e21,
-                       "small": 1e-7, "pi": 3.141592653589793},
-        }),
+        ),
     ),
     (
         "G-04-key-order",
         "post_model_call with keys supplied in reverse order",
-        ctx("post_model_call", 3, {
-            "model": {"id": "m"},
-            "response": {"finish_reason": "stop", "tool_calls": [],
-                         "content": {"z": 1, "a": 2, "m": 3}},
-            "target": {"finish_reason": "stop", "tool_calls": [],
-                       "content": {"z": 1, "a": 2, "m": 3}},
-        }),
+        ctx(
+            "post_model_call",
+            3,
+            {
+                "model": {"id": "m"},
+                "response": {
+                    "finish_reason": "stop",
+                    "tool_calls": [],
+                    "content": {"z": 1, "a": 2, "m": 3},
+                },
+                "target": {
+                    "finish_reason": "stop",
+                    "tool_calls": [],
+                    "content": {"z": 1, "a": 2, "m": 3},
+                },
+            },
+        ),
     ),
     (
         "G-05-l2-l3-stripped",
         "L2 (trace, budgets, agent.name) and L3 (extensions) MUST NOT affect identity",
-        ctx("input", 1, {
-            "input": {"content": "hi", "role": "user"},
-            "target": {"content": "hi", "role": "user"},
-            "agent": {"id": "agent-1", "framework": "reference",
-                      "name": "IGNORED", "version": "IGNORED"},
-            "session": {"id": "sess-1", "started_at": "IGNORED", "turn": 99},
-            "trace": {"trace_id": "IGNORED"},
-            "budgets": {"tool_call_count": 999},
-            "extensions": {"acs": {"anything": True}},
-        }),
+        ctx(
+            "input",
+            1,
+            {
+                "input": {"content": "hi", "role": "user"},
+                "target": {"content": "hi", "role": "user"},
+                "agent": {
+                    "id": "agent-1",
+                    "framework": "reference",
+                    "name": "IGNORED",
+                    "version": "IGNORED",
+                },
+                "session": {"id": "sess-1", "started_at": "IGNORED", "turn": 99},
+                "trace": {"trace_id": "IGNORED"},
+                "budgets": {"tool_call_count": 999},
+                "extensions": {"acs": {"anything": True}},
+            },
+        ),
     ),
     (
         "G-05b-l2-l3-baseline",
         "same required+conditional fields as G-05 without optional/namespaced ones; identity MUST equal G-05",
-        ctx("input", 1, {
-            "input": {"content": "hi", "role": "user"},
-            "target": {"content": "hi", "role": "user"},
-        }),
+        ctx(
+            "input",
+            1,
+            {
+                "input": {"content": "hi", "role": "user"},
+                "target": {"content": "hi", "role": "user"},
+            },
+        ),
     ),
     (
         "G-06-nested-array",
         "pre_model_call with nested message array",
-        ctx("pre_model_call", 2, {
-            "model": {"id": "gpt-x"},
-            "messages": [
-                {"role": "system", "content": "a"},
-                {"role": "user", "content": {"parts": [1, 2, {"k": "v"}]}},
-            ],
-            "target": [
-                {"role": "system", "content": "a"},
-                {"role": "user", "content": {"parts": [1, 2, {"k": "v"}]}},
-            ],
-        }),
+        ctx(
+            "pre_model_call",
+            2,
+            {
+                "model": {"id": "gpt-x"},
+                "messages": [
+                    {"role": "system", "content": "a"},
+                    {"role": "user", "content": {"parts": [1, 2, {"k": "v"}]}},
+                ],
+                "target": [
+                    {"role": "system", "content": "a"},
+                    {"role": "user", "content": {"parts": [1, 2, {"k": "v"}]}},
+                ],
+            },
+        ),
     ),
     (
         "G-07-post-tool-null",
         "post_tool_call with null result value",
-        ctx("post_tool_call", 5, {
-            "tool_call": {"id": "tc-1", "name": "t", "args": {}},
-            "tool_result": {"value": None, "is_error": False},
-            "target": None,
-        }),
+        ctx(
+            "post_tool_call",
+            5,
+            {
+                "tool_call": {"id": "tc-1", "name": "t", "args": {}},
+                "tool_result": {"value": None, "is_error": False},
+                "target": None,
+            },
+        ),
     ),
     (
         "G-08-output-escapes",
         "output with control chars requiring escape",
-        ctx("output", 6, {
-            "output": {"content": "line1\nline2\t\"q\"\\end"},
-            "target": {"content": "line1\nline2\t\"q\"\\end"},
-        }),
+        ctx(
+            "output",
+            6,
+            {
+                "output": {"content": 'line1\nline2\t"q"\\end'},
+                "target": {"content": 'line1\nline2\t"q"\\end'},
+            },
+        ),
     ),
     (
         "G-09-shutdown",
         "agent_shutdown baseline",
-        ctx("agent_shutdown", 7, {
-            "summary": {"reason": "completed"},
-            "target": {"reason": "completed"},
-        }),
+        ctx(
+            "agent_shutdown",
+            7,
+            {
+                "summary": {"reason": "completed"},
+                "target": {"reason": "completed"},
+            },
+        ),
     ),
     (
         "G-10-empty-target",
         "pre_tool_call with empty args object",
-        ctx("pre_tool_call", 4, {
-            "tool_call": {"id": "tc-1", "name": "noop", "args": {}},
-            "target": {},
-        }),
+        ctx(
+            "pre_tool_call",
+            4,
+            {
+                "tool_call": {"id": "tc-1", "name": "noop", "args": {}},
+                "target": {},
+            },
+        ),
     ),
     (
         "G-11-utf16-key-order",
@@ -151,63 +221,126 @@ FIXTURES: list[tuple[str, str, dict]] = [
         "first unit 0xD800) MUST sort before U+E000 despite the higher "
         "code point — the exact case where code-point sorters diverge. "
         "Empty key sorts first.",
-        ctx("pre_tool_call", 8, {
-            "tool_call": {"id": "tc-2", "name": "k", "args": {
-                "": 1, "\ue000": 2, "\U00010000": 3, "z": 4, "\u00e9": 5,
-            }},
-            "target": {
-                "": 1, "\ue000": 2, "\U00010000": 3, "z": 4, "\u00e9": 5,
+        ctx(
+            "pre_tool_call",
+            8,
+            {
+                "tool_call": {
+                    "id": "tc-2",
+                    "name": "k",
+                    "args": {
+                        "": 1,
+                        "\ue000": 2,
+                        "\U00010000": 3,
+                        "z": 4,
+                        "\u00e9": 5,
+                    },
+                },
+                "target": {
+                    "": 1,
+                    "\ue000": 2,
+                    "\U00010000": 3,
+                    "z": 4,
+                    "\u00e9": 5,
+                },
             },
-        }),
+        ),
     ),
     (
         "G-12-non-ascii-keys",
         "non-ASCII member names (accented, CJK, emoji) survive "
         "canonicalization unescaped and sort by UTF-16 units",
-        ctx("pre_tool_call", 9, {
-            "tool_call": {"id": "tc-3", "name": "k", "args": {
-                "中文": 1, "émoji🎯": 2, "ascii": 3,
-            }},
-            "target": {"中文": 1, "émoji🎯": 2, "ascii": 3},
-        }),
+        ctx(
+            "pre_tool_call",
+            9,
+            {
+                "tool_call": {
+                    "id": "tc-3",
+                    "name": "k",
+                    "args": {
+                        "中文": 1,
+                        "émoji🎯": 2,
+                        "ascii": 3,
+                    },
+                },
+                "target": {"中文": 1, "émoji🎯": 2, "ascii": 3},
+            },
+        ),
     ),
     (
         "G-13-int53-boundaries",
         "±(2^53−1) are the largest integral values inside the I-JSON "
         "domain (§10.2); one past either bound is rejected (see the "
         "negative fixtures)",
-        ctx("pre_tool_call", 10, {
-            "tool_call": {"id": "tc-4", "name": "k", "args": {
-                "max": 9007199254740991, "min": -9007199254740991,
-            }},
-            "target": {"max": 9007199254740991, "min": -9007199254740991},
-        }),
+        ctx(
+            "pre_tool_call",
+            10,
+            {
+                "tool_call": {
+                    "id": "tc-4",
+                    "name": "k",
+                    "args": {
+                        "max": 9007199254740991,
+                        "min": -9007199254740991,
+                    },
+                },
+                "target": {"max": 9007199254740991, "min": -9007199254740991},
+            },
+        ),
     ),
     (
         "G-14-string-encoded-int64",
         "the §4.4 convention: 64-bit identifiers as decimal strings pass "
         "through byte-faithfully and never collide with numeric siblings",
-        ctx("pre_tool_call", 11, {
-            "tool_call": {"id": "tc-5", "name": "k", "args": {
-                "id": "9223372036854775807", "small": 42,
-            }},
-            "target": {"id": "9223372036854775807", "small": 42},
-        }),
+        ctx(
+            "pre_tool_call",
+            11,
+            {
+                "tool_call": {
+                    "id": "tc-5",
+                    "name": "k",
+                    "args": {
+                        "id": "9223372036854775807",
+                        "small": 42,
+                    },
+                },
+                "target": {"id": "9223372036854775807", "small": 42},
+            },
+        ),
     ),
     (
         "G-15-rfc8785-numbers",
         "ECMA-262 Number::toString forms from the RFC 8785 test corpus "
         "(in-domain subset): trailing-zero drop, exponent thresholds, "
         "shortest round-trip",
-        ctx("pre_tool_call", 12, {
-            "tool_call": {"id": "tc-6", "name": "k", "args": {
-                "a": 56.0, "b": 0.000001, "c": 1e-7, "d": 333333333.33333329,
-                "e": 1e21, "f": 9.999999999999997e22, "g": 0.1,
-            }},
-            "target": {"a": 56.0, "b": 0.000001, "c": 1e-7,
-                       "d": 333333333.33333329, "e": 1e21,
-                       "f": 9.999999999999997e22, "g": 0.1},
-        }),
+        ctx(
+            "pre_tool_call",
+            12,
+            {
+                "tool_call": {
+                    "id": "tc-6",
+                    "name": "k",
+                    "args": {
+                        "a": 56.0,
+                        "b": 0.000001,
+                        "c": 1e-7,
+                        "d": 333333333.33333329,
+                        "e": 1e21,
+                        "f": 9.999999999999997e22,
+                        "g": 0.1,
+                    },
+                },
+                "target": {
+                    "a": 56.0,
+                    "b": 0.000001,
+                    "c": 1e-7,
+                    "d": 333333333.33333329,
+                    "e": 1e21,
+                    "f": 9.999999999999997e22,
+                    "g": 0.1,
+                },
+            },
+        ),
     ),
 ]
 
@@ -217,11 +350,18 @@ NEGATIVE_FIXTURES: list[tuple[str, str, dict]] = [
     (
         "G-N01-integral-beyond-2-53",
         "2^53 itself is out of domain: canonicalization would round",
-        ctx("pre_tool_call", 13, {
-            "tool_call": {"id": "tc-7", "name": "k",
-                          "args": {"id": 9007199254740992}},
-            "target": {"id": 9007199254740992},
-        }),
+        ctx(
+            "pre_tool_call",
+            13,
+            {
+                "tool_call": {
+                    "id": "tc-7",
+                    "name": "k",
+                    "args": {"id": 9007199254740992},
+                },
+                "target": {"id": 9007199254740992},
+            },
+        ),
     ),
     (
         "G-N02-missing-conditional",
@@ -237,12 +377,14 @@ def main() -> None:
         ctx_json = json.dumps(c, ensure_ascii=False)
         canon = _core.canonical_json(ctx_json)
         ident = _core.context_identity(ctx_json)
-        out.append({
-            "id": fid,
-            "note": note,
-            "ctx": c,
-            "expect": {"canonical_json": canon, "context_identity": ident},
-        })
+        out.append(
+            {
+                "id": fid,
+                "note": note,
+                "ctx": c,
+                "expect": {"canonical_json": canon, "context_identity": ident},
+            }
+        )
     for fid, note, c in NEGATIVE_FIXTURES:
         ctx_json = json.dumps(c, ensure_ascii=False)
         try:
@@ -250,12 +392,14 @@ def main() -> None:
             raise SystemExit(f"{fid}: expected rejection, got an identity")
         except Exception:
             pass
-        out.append({
-            "id": fid,
-            "note": note,
-            "ctx": c,
-            "expect": {"error": "host_error:context_invalid"},
-        })
+        out.append(
+            {
+                "id": fid,
+                "note": note,
+                "ctx": c,
+                "expect": {"error": "host_error:context_invalid"},
+            }
+        )
     # G-05 and G-05b MUST have identical identity (L2/L3 stripped).
     g05 = next(f for f in out if f["id"] == "G-05-l2-l3-stripped")
     g05b = next(f for f in out if f["id"] == "G-05b-l2-l3-baseline")

--- a/scripts/gen-per-point-schemas.py
+++ b/scripts/gen-per-point-schemas.py
@@ -5,6 +5,7 @@ Each per-point schema is a closed (additionalProperties: false on the L1
 payload object) variant of agent-context.schema.json restricted to one
 interception_point value, used by the CTK for strict validation.
 """
+
 from __future__ import annotations
 
 import json
@@ -26,7 +27,15 @@ L1: dict[str, tuple[list[str], list[str]]] = {
     "agent_shutdown": (["summary"], ["summary"]),
 }
 
-CORE_REQUIRED = ["spec", "interception_point", "timestamp", "sequence", "agent", "session", "target"]
+CORE_REQUIRED = [
+    "spec",
+    "interception_point",
+    "timestamp",
+    "sequence",
+    "agent",
+    "session",
+    "target",
+]
 
 
 def main() -> None:

--- a/sdk/dotnet/src/AgentHooks.Conformance/ReferenceHarness.cs
+++ b/sdk/dotnet/src/AgentHooks.Conformance/ReferenceHarness.cs
@@ -179,7 +179,8 @@ public sealed class ReferenceHarness : IHarness
         var (value, isError) = s.Tools[name].Invoke(postArgs);
         _toolLog.Add(new JsonObject
         {
-            ["name"] = name, ["args"] = postArgs.DeepClone(),
+            ["name"] = name,
+            ["args"] = postArgs.DeepClone(),
         });
 
         await em.EmitAsync(
@@ -188,7 +189,8 @@ public sealed class ReferenceHarness : IHarness
 
         messages.Add(new JsonObject
         {
-            ["role"] = "tool", ["content"] = value?.DeepClone(),
+            ["role"] = "tool",
+            ["content"] = value?.DeepClone(),
         });
     }
 }

--- a/sdk/dotnet/src/AgentHooks.Conformance/Runner.cs
+++ b/sdk/dotnet/src/AgentHooks.Conformance/Runner.cs
@@ -132,7 +132,8 @@ public static class Runner
         foreach (var (i, e) in rr.Identities ?? [])
             identities.Add(new JsonObject
             {
-                ["input_identity"] = i, ["enforced_identity"] = e,
+                ["input_identity"] = i,
+                ["enforced_identity"] = e,
             });
         var records = new JsonArray(
             (rr.Records ?? []).Select(r => (JsonNode)r.DeepClone()).ToArray());

--- a/sdk/dotnet/src/AgentHooks/AgentContextBuilder.cs
+++ b/sdk/dotnet/src/AgentHooks/AgentContextBuilder.cs
@@ -118,7 +118,9 @@ public sealed class AgentContextBuilder
     {
         var tc = new JsonObject
         {
-            ["id"] = callId, ["name"] = name, ["args"] = args.DeepClone(),
+            ["id"] = callId,
+            ["name"] = name,
+            ["args"] = args.DeepClone(),
         };
         var ctx = Envelope(InterceptionPoint.PreToolCall, args);
         ctx["tool_call"] = tc;
@@ -133,7 +135,9 @@ public sealed class AgentContextBuilder
         var ctx = Envelope(InterceptionPoint.PostToolCall, value);
         ctx["tool_call"] = new JsonObject
         {
-            ["id"] = callId, ["name"] = name, ["args"] = args.DeepClone(),
+            ["id"] = callId,
+            ["name"] = name,
+            ["args"] = args.DeepClone(),
         };
         ctx["tool_result"] = tr;
         return ctx;

--- a/sdk/dotnet/src/AgentHooks/InterceptionEmitter.cs
+++ b/sdk/dotnet/src/AgentHooks/InterceptionEmitter.cs
@@ -157,7 +157,13 @@ public sealed class InterceptionEmitter
         return this;
     }
 
-    /// <summary>Declare the composition profile for subsequent emissions (§7.1).</summary>
+    /// <summary>Declare the composition profile for subsequent emissions (§7.1).
+    /// The default (<c>sequential/first_deny</c>, <c>on_approval: stop</c>) is the
+    /// configuration §14 warns about: after an approval lifts a liftable deny,
+    /// interceptors registered after the escalating one never run for that
+    /// emission (<c>fold_truncated</c> on the record). Register must-run controls
+    /// first, or use <c>sequential/run_all</c> / a parallel profile.
+    /// See docs/PRODUCTION.md.</summary>
     public InterceptionEmitter SetComposition(CompositionConfig composition)
     {
         _composition = composition;
@@ -448,64 +454,64 @@ public sealed class InterceptionEmitter
             switch (v.Decision)
             {
                 case Decision.Deny:
-                {
-                    var c = await ConsultAsync(ctx, v, ct);
-                    if (c is null)
                     {
-                        return new DispatchOutcome(
-                            WithUnions(v, pool), i, Summaries(perInterceptor),
-                            Truncated(i), resolvedBy);
+                        var c = await ConsultAsync(ctx, v, ct);
+                        if (c is null)
+                        {
+                            return new DispatchOutcome(
+                                WithUnions(v, pool), i, Summaries(perInterceptor),
+                                Truncated(i), resolvedBy);
+                        }
+                        if (!c.Permitted)
+                        {
+                            // Reject / unresolved / echo violation: a deny
+                            // stands (§9); the consultation is still
+                            // recorded (§10.3 resolved_by).
+                            return new DispatchOutcome(
+                                WithUnions(c.Verdict, pool),
+                                IsHostSynthesized(c.Verdict) ? null : i,
+                                Summaries(perInterceptor), Truncated(i), "rejection");
+                        }
+                        resolvedBy = "approval";
+                        // §7.6: the permit resolution substitutes at this
+                        // position; its transform folds like an interceptor's
+                        // (§7.4).
+                        var sub = c.Verdict.Decision == Decision.Transform
+                            ? FoldTransform(ctx, c.Verdict)
+                            : c.Verdict;
+                        if (!sub.Decision.Permits())
+                        {
+                            return new DispatchOutcome(
+                                sub, null, Summaries(perInterceptor),
+                                Truncated(i), resolvedBy);
+                        }
+                        pool.Add(sub);
+                        if (onApproval == OnApproval.Stop)
+                        {
+                            // §7.4 stop: the resolution is the combined
+                            // verdict; the emission ends. fold_truncated makes
+                            // the skip legible.
+                            return new DispatchOutcome(
+                                WithUnions(sub, pool), i, Summaries(perInterceptor),
+                                Truncated(i), resolvedBy);
+                        }
+                        if (sub.Decision == Decision.Transform)
+                            lastTransform = (i, sub);
+                        break; // resume: fold continues at i+1
                     }
-                    if (!c.Permitted)
-                    {
-                        // Reject / unresolved / echo violation: a deny
-                        // stands (§9); the consultation is still
-                        // recorded (§10.3 resolved_by).
-                        return new DispatchOutcome(
-                            WithUnions(c.Verdict, pool),
-                            IsHostSynthesized(c.Verdict) ? null : i,
-                            Summaries(perInterceptor), Truncated(i), "rejection");
-                    }
-                    resolvedBy = "approval";
-                    // §7.6: the permit resolution substitutes at this
-                    // position; its transform folds like an interceptor's
-                    // (§7.4).
-                    var sub = c.Verdict.Decision == Decision.Transform
-                        ? FoldTransform(ctx, c.Verdict)
-                        : c.Verdict;
-                    if (!sub.Decision.Permits())
-                    {
-                        return new DispatchOutcome(
-                            sub, null, Summaries(perInterceptor),
-                            Truncated(i), resolvedBy);
-                    }
-                    pool.Add(sub);
-                    if (onApproval == OnApproval.Stop)
-                    {
-                        // §7.4 stop: the resolution is the combined
-                        // verdict; the emission ends. fold_truncated makes
-                        // the skip legible.
-                        return new DispatchOutcome(
-                            WithUnions(sub, pool), i, Summaries(perInterceptor),
-                            Truncated(i), resolvedBy);
-                    }
-                    if (sub.Decision == Decision.Transform)
-                        lastTransform = (i, sub);
-                    break; // resume: fold continues at i+1
-                }
                 case Decision.Transform:
-                {
-                    var folded = FoldTransform(ctx, v);
-                    if (!folded.Decision.Permits())
                     {
-                        // Transform failed closed (host-synthesized §5.2).
-                        return new DispatchOutcome(
-                            folded, null, Summaries(perInterceptor),
-                            Truncated(i), resolvedBy);
+                        var folded = FoldTransform(ctx, v);
+                        if (!folded.Decision.Permits())
+                        {
+                            // Transform failed closed (host-synthesized §5.2).
+                            return new DispatchOutcome(
+                                folded, null, Summaries(perInterceptor),
+                                Truncated(i), resolvedBy);
+                        }
+                        lastTransform = (i, folded);
+                        break;
                     }
-                    lastTransform = (i, folded);
-                    break;
-                }
             }
         }
 

--- a/sdk/go/agenthooks/emitter.go
+++ b/sdk/go/agenthooks/emitter.go
@@ -228,6 +228,13 @@ func (e *InterceptionEmitter) Mode() EnforcementMode { return e.mode }
 
 // SetComposition declares the composition profile for subsequent
 // emissions (§7.1). An empty profile resets to the default.
+//
+// The default (sequential/first_deny, on_approval: stop) is the
+// configuration §14 warns about: after an approval lifts a liftable
+// deny, interceptors registered after the escalating one never run for
+// that emission (fold_truncated on the record). Register must-run
+// controls first, or use sequential/run_all / a parallel profile.
+// See docs/PRODUCTION.md.
 func (e *InterceptionEmitter) SetComposition(c CompositionConfig) *InterceptionEmitter {
 	if c.Profile == "" {
 		c = DefaultComposition()

--- a/sdk/go/agenthooks/emitter.go
+++ b/sdk/go/agenthooks/emitter.go
@@ -393,13 +393,13 @@ func (e *InterceptionEmitter) EmitUnchecked(ctx context.Context, actx AgentConte
 	}
 
 	opts := map[string]any{
-		"input_identity":    inputID,
-		"identity_provider": e.identity.name(),
-		"decided_by":        outcome.decidedBy,
-		"composition":       e.composition,
-		"verdicts":          outcome.verdicts,
-		"fold_truncated":    outcome.foldTruncated,
-		"resolved_by":       outcome.resolvedBy,
+		"input_identity":          inputID,
+		"identity_provider":       e.identity.name(),
+		"decided_by":              outcome.decidedBy,
+		"composition":             e.composition,
+		"verdicts":                outcome.verdicts,
+		"fold_truncated":          outcome.foldTruncated,
+		"resolved_by":             outcome.resolvedBy,
 		"interceptors_registered": len(e.interceptors),
 	}
 	if e.identity != nil && e.identity.Compute != nil {

--- a/sdk/python/python/agent_hooks/__init__.py
+++ b/sdk/python/python/agent_hooks/__init__.py
@@ -18,6 +18,7 @@ text. This package provides:
 - :class:`IdentityProvider`, :func:`canonical_json`, :func:`context_identity` — §10
 - :mod:`agent_hooks.ctk` — Conformance Test Kit (§13)
 """
+
 from __future__ import annotations
 
 from agent_hooks._types import (

--- a/sdk/python/python/agent_hooks/_core.pyi
+++ b/sdk/python/python/agent_hooks/_core.pyi
@@ -6,6 +6,7 @@ SPEC_VERSION: str
 class AgentHooksCoreError(ValueError):
     """Raised by every _core function on failure. ``.code`` is the §11
     ``host_error:*`` wire string."""
+
     code: str
 
 def spec_version() -> str: ...

--- a/sdk/python/python/agent_hooks/_marshal.py
+++ b/sdk/python/python/agent_hooks/_marshal.py
@@ -10,6 +10,7 @@ wire JSON. The emitter maps that failure to a fail-closed
 ``host_error:context_invalid`` deny (§10.2: fail closed, never
 normalize).
 """
+
 from __future__ import annotations
 
 import json

--- a/sdk/python/python/agent_hooks/_types.py
+++ b/sdk/python/python/agent_hooks/_types.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """Core enums and value types for AGENT-HOOKS-0.1 (§3, §5, §8, §10.3, §11)."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -101,9 +102,7 @@ class Transform:
 
     def __post_init__(self) -> None:
         if not (self.path.startswith("$target") or self.path.startswith("$policy_target")):
-            raise ValueError(
-                f"transform.path must be rooted at $target (got {self.path!r})"
-            )
+            raise ValueError(f"transform.path must be rooted at $target (got {self.path!r})")
 
     def to_wire(self) -> dict[str, Any]:
         # Mirrors the core: value serialized only when non-null; the
@@ -161,9 +160,7 @@ class Warning:
         if not isinstance(obj, dict):
             raise ValueError("warnings must be an array of objects (§5)")
         reason = obj.get("reason")
-        if reason is not None and (
-            not isinstance(reason, str) or reason.startswith("host_error:")
-        ):
+        if reason is not None and (not isinstance(reason, str) or reason.startswith("host_error:")):
             raise ValueError("warnings[].reason must be a non-reserved string")
         message = obj.get("message")
         if message is not None and not isinstance(message, str):
@@ -479,9 +476,7 @@ class InterceptionRecord:
             sequence=obj.get("sequence", -1),
             decided_by=obj.get("decided_by"),
             composition=CompositionConfig.from_wire(obj.get("composition")),
-            verdicts=tuple(
-                VerdictSummary.from_wire(v) for v in obj.get("verdicts") or ()
-            ),
+            verdicts=tuple(VerdictSummary.from_wire(v) for v in obj.get("verdicts") or ()),
             fold_truncated=obj.get("fold_truncated"),
             resolved_by=obj.get("resolved_by"),
             interceptors_registered=obj.get("interceptors_registered", 0),

--- a/sdk/python/python/agent_hooks/approval.py
+++ b/sdk/python/python/agent_hooks/approval.py
@@ -13,6 +13,7 @@ conformant behaviour, not an error.
 (§10.1) — the approval is then identity-unbound and the echo rule
 applies to ``None`` itself.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/sdk/python/python/agent_hooks/canonical.py
+++ b/sdk/python/python/agent_hooks/canonical.py
@@ -6,6 +6,7 @@ Delegates to the Rust core (``agent_hooks._core``) so every SDK produces
 byte-identical output. The pure-Python implementation was removed once the
 core became canonical (see ``sdk/rust/core/src/canonical.rs``).
 """
+
 from __future__ import annotations
 
 from typing import Any

--- a/sdk/python/python/agent_hooks/composition.py
+++ b/sdk/python/python/agent_hooks/composition.py
@@ -11,6 +11,7 @@ Aggregation itself (severity-max winner, §7.3 metadata unions) delegates
 to the Rust core (``_core.compose_aggregate``) so all SDKs agree byte
 for byte; this module carries only the configuration value type.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -79,9 +80,7 @@ class CompositionConfig:
 
     @classmethod
     def first_deny(cls, on_approval: OnApproval = OnApproval.STOP) -> CompositionConfig:
-        return cls(
-            profile=CompositionProfile.SEQUENTIAL_FIRST_DENY, on_approval=on_approval
-        )
+        return cls(profile=CompositionProfile.SEQUENTIAL_FIRST_DENY, on_approval=on_approval)
 
     @classmethod
     def run_all(cls) -> CompositionConfig:

--- a/sdk/python/python/agent_hooks/context.py
+++ b/sdk/python/python/agent_hooks/context.py
@@ -7,6 +7,7 @@ JSON without translation. :class:`AgentContextBuilder` is the host-side helper
 that owns the L0 envelope (agent/session/sequence) and exposes one method per
 interception point that fills L1 and sets ``target``.
 """
+
 from __future__ import annotations
 
 import itertools

--- a/sdk/python/python/agent_hooks/ctk/__init__.py
+++ b/sdk/python/python/agent_hooks/ctk/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """Conformance Test Kit (§13)."""
+
 from __future__ import annotations
 
 from agent_hooks.ctk.harness import Capability, Harness, RunOutcome, RunRecord, Scenario

--- a/sdk/python/python/agent_hooks/ctk/_schemas.py
+++ b/sdk/python/python/agent_hooks/ctk/_schemas.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """Lazy loader for the vendored JSON schemas under ``agent_hooks/schema/``."""
+
 from __future__ import annotations
 
 import functools

--- a/sdk/python/python/agent_hooks/ctk/harness.py
+++ b/sdk/python/python/agent_hooks/ctk/harness.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """CTK harness contract a framework adapter implements once (§13.2)."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/sdk/python/python/agent_hooks/ctk/plugin.py
+++ b/sdk/python/python/agent_hooks/ctk/plugin.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """pytest plugin: ``pytest --agent-hooks-harness=... --agent-hooks-vectors=...``."""
+
 from __future__ import annotations
 
 import importlib

--- a/sdk/python/python/agent_hooks/ctk/reference.py
+++ b/sdk/python/python/agent_hooks/ctk/reference.py
@@ -5,6 +5,7 @@
 This is the simplest possible conformant agent loop: it exists so the
 CTK can self-test without depending on any real framework.
 """
+
 from __future__ import annotations
 
 import json
@@ -95,9 +96,7 @@ class ReferenceHarness:
         final: Any | None = None
         try:
             await em.emit(b.agent_startup(tools_registered=sorted(s.tools)))
-            await em.emit(
-                b.input(content=s.input["content"], role=s.input["role"])
-            )
+            await em.emit(b.input(content=s.input["content"], role=s.input["role"]))
             messages: list[dict[str, Any]] = [
                 {"role": s.input["role"], "content": s.input["content"]}
             ]
@@ -136,17 +135,13 @@ class ReferenceHarness:
             outcome = RunOutcome.BLOCKED
             final = None
         await em.emit_unchecked(
-            b.agent_shutdown(
-                reason="completed" if outcome is RunOutcome.COMPLETED else "error"
-            )
+            b.agent_shutdown(reason="completed" if outcome is RunOutcome.COMPLETED else "error")
         )
         return RunRecord(
             outcome=outcome,
             final_output=final,
             tool_invocations=list(self._tool_log),
-            identities=[
-                (r.input_identity, r.enforced_identity) for r in em.results
-            ],
+            identities=[(r.input_identity, r.enforced_identity) for r in em.results],
             records=[r.to_wire() for r in em.results],
         )
 
@@ -155,9 +150,7 @@ class ReferenceHarness:
 
     # ---- internals ----------------------------------------------------------
 
-    async def _do_tool_call(
-        self, tc: dict[str, Any], messages: list[dict[str, Any]]
-    ) -> None:
+    async def _do_tool_call(self, tc: dict[str, Any], messages: list[dict[str, Any]]) -> None:
         assert self._scenario and self._emitter and self._builder
         s, em, b = self._scenario, self._emitter, self._builder
         ctx = b.pre_tool_call(call_id=tc["id"], name=tc["name"], args=dict(tc["args"]))
@@ -179,6 +172,7 @@ def _provider_of(declared: str | None):
     (§13.2): "ctk-fault" is a custom provider that raises, pinning the
     §10.1 provider-failure rule."""
     if declared == "ctk-fault":
+
         def _boom(_ctx: object) -> str:
             raise RuntimeError("ctk scripted provider fault")
 

--- a/sdk/python/python/agent_hooks/ctk/runner.py
+++ b/sdk/python/python/agent_hooks/ctk/runner.py
@@ -13,6 +13,7 @@ interceptor/resolver evaluation live in the Rust core
 
 Every other language SDK's runner has the same shape.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -75,9 +76,7 @@ def _run_record_to_wire(rr: RunRecord) -> str:
             "final_output": rr.final_output,
             "tool_invocations": rr.tool_invocations,
             "error": rr.error,
-            "identities": [
-                {"input_identity": i, "enforced_identity": e} for i, e in rr.identities
-            ],
+            "identities": [{"input_identity": i, "enforced_identity": e} for i, e in rr.identities],
             "records": rr.records,
         }
     )

--- a/sdk/python/python/agent_hooks/ctk/scripted.py
+++ b/sdk/python/python/agent_hooks/ctk/scripted.py
@@ -7,6 +7,7 @@ this module keeps only the recording wrapper (which must capture what
 the *native* harness passed, so it stays per-language) and the
 Approval type marshalling.
 """
+
 from __future__ import annotations
 
 import copy
@@ -78,9 +79,7 @@ class ScriptedResolver:
         # engine works in strings; "" round-trips to None below.
         request_identity = request.context_identity or ""
         r = json.loads(
-            _core.ctk_scripted_resolve(
-                self._rules_json, dumps(request.context), request_identity
-            )
+            _core.ctk_scripted_resolve(self._rules_json, dumps(request.context), request_identity)
         )
         if "__ctk_fault__" in r:
             # NOW-10 fault injection: exercise §9 approval_resolver_failed.

--- a/sdk/python/python/agent_hooks/emitter.py
+++ b/sdk/python/python/agent_hooks/emitter.py
@@ -32,6 +32,7 @@ on the event loop; ``sequence`` assignment and record append are atomic
 under a single-threaded asyncio runtime. Sharing one emitter across OS
 threads is not supported.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -282,8 +283,7 @@ class InterceptionEmitter:
         # reserved so a custom function can never claim golden-vector
         # semantics on records.
         if isinstance(provider, IdentityProvider) and (
-            not re.fullmatch(r"[a-z][a-z0-9_-]*", provider.name)
-            or provider.name.startswith("jcs")
+            not re.fullmatch(r"[a-z][a-z0-9_-]*", provider.name) or provider.name.startswith("jcs")
         ):
             raise ValueError(
                 "identity provider name must match ^[a-z][a-z0-9_-]*$ "
@@ -304,9 +304,7 @@ class InterceptionEmitter:
         """All interception records emitted so far in this session, in order."""
         return list(self._records)
 
-    def register(
-        self, interceptor: Interceptor, name: str | None = None
-    ) -> InterceptionEmitter:
+    def register(self, interceptor: Interceptor, name: str | None = None) -> InterceptionEmitter:
         """Register an interceptor, optionally with a host-chosen
         payload-free ``name`` recorded on ``verdicts[].name`` (§10.3)."""
         self._interceptors.append(interceptor)
@@ -314,13 +312,19 @@ class InterceptionEmitter:
         return self
 
     def set_composition(self, composition: CompositionConfig) -> InterceptionEmitter:
-        """Declare the composition profile for subsequent emissions (§7.1)."""
+        """Declare the composition profile for subsequent emissions (§7.1).
+
+        The default (``sequential/first_deny``, ``on_approval: stop``)
+        is the configuration §14 warns about: after an approval lifts a
+        liftable deny, interceptors registered after the escalating one
+        never run for that emission (``fold_truncated`` on the record).
+        Register must-run controls first, or use ``sequential/run_all``
+        / a parallel profile. See docs/PRODUCTION.md.
+        """
         self._composition = composition
         return self
 
-    def set_identity_provider(
-        self, provider: str | IdentityProvider | None
-    ) -> InterceptionEmitter:
+    def set_identity_provider(self, provider: str | IdentityProvider | None) -> InterceptionEmitter:
         """Declare the identity provider (§10.1)."""
         self._identity = self._check_provider(provider)
         return self
@@ -337,9 +341,7 @@ class InterceptionEmitter:
         self._approval_redactor = redactor
         return self
 
-    def set_record_sink(
-        self, sink: Callable[[InterceptionRecord], None]
-    ) -> InterceptionEmitter:
+    def set_record_sink(self, sink: Callable[[InterceptionRecord], None]) -> InterceptionEmitter:
         """Register a per-emission record callback (§10.3), invoked
         synchronously after every emission before buffering; a sink
         exception is swallowed (audit delivery is the host's liveness
@@ -407,14 +409,10 @@ class InterceptionEmitter:
             )
         except ValueError as e:
             outcome = _Outcome(
-                Verdict.host_error(
-                    HostError.CONTEXT_INVALID, f"context is not RFC 8259 JSON: {e}"
-                )
+                Verdict.host_error(HostError.CONTEXT_INVALID, f"context is not RFC 8259 JSON: {e}")
             )
         except Exception as e:  # noqa: BLE001 — custom provider raised; fail closed
-            outcome = _Outcome(
-                Verdict.host_error(HostError.CONTEXT_INVALID, type(e).__name__)
-            )
+            outcome = _Outcome(Verdict.host_error(HostError.CONTEXT_INVALID, type(e).__name__))
         if outcome is None:
             outcome = await self._dispatch(ctx)
 
@@ -475,9 +473,7 @@ class InterceptionEmitter:
                 options["enforced_identity"] = None
         verdict_json = dumps(outcome.combined.to_wire())
         try:
-            record_json = _core.finalize(
-                dumps(ctx), verdict_json, self._mode.value, dumps(options)
-            )
+            record_json = _core.finalize(dumps(ctx), verdict_json, self._mode.value, dumps(options))
         except ValueError:
             # The context cannot cross the FFI boundary intact (the
             # emission already failed closed above); record the envelope
@@ -691,22 +687,14 @@ class InterceptionEmitter:
                 rv, permitted = consultation
                 if permitted:
                     resolved_by = "approval"
-                    sub = (
-                        self._fold_transform(ctx, rv)
-                        if rv.decision is Decision.TRANSFORM
-                        else rv
-                    )
+                    sub = self._fold_transform(ctx, rv) if rv.decision is Decision.TRANSFORM else rv
                     # §7.3 step 2: the substituting resolution carries
                     # the emission's unions — uniformly, including for a
                     # §7.5-synthesized trigger (whose `decided_by` is
                     # already None from the aggregation).
                     # (falls back bare when a substituted transform
                     # failed closed)
-                    combined = (
-                        _with_unions(sub, [*all_v, sub])
-                        if sub.decision.permits
-                        else sub
-                    )
+                    combined = _with_unions(sub, [*all_v, sub]) if sub.decision.permits else sub
                 else:
                     # §10.3: consultation without a permit substitution.
                     resolved_by = "rejection"
@@ -731,18 +719,14 @@ class InterceptionEmitter:
                 ctx.clear()
                 ctx.update(new_ctx)
             else:
-                _core.validate_transform_ctx(
-                    dumps(ctx), v.transform.path, dumps(v.transform.value)
-                )
+                _core.validate_transform_ctx(dumps(ctx), v.transform.path, dumps(v.transform.value))
         except _core.AgentHooksCoreError as e:
             return Verdict.host_error(_host_error_of(e, HostError.TRANSFORM_INVALID), str(e))
         except ValueError as e:
             return Verdict.host_error(HostError.TRANSFORM_INVALID, str(e))
         return v
 
-    async def _consult(
-        self, ctx: AgentContext, verdict: Verdict
-    ) -> tuple[Verdict, bool] | None:
+    async def _consult(self, ctx: AgentContext, verdict: Verdict) -> tuple[Verdict, bool] | None:
         """Consult the approval seam for a liftable deny (§9), when the
         profile conditions allow it: ``enforce`` mode, not
         ``agent_shutdown``, a resolver registered, and the verdict
@@ -771,9 +755,7 @@ class InterceptionEmitter:
                 presented = self._approval_redactor(ctx)
             except Exception as e:  # noqa: BLE001
                 return (
-                    Verdict.host_error(
-                        HostError.APPROVAL_RESOLVER_FAILED, type(e).__name__
-                    ),
+                    Verdict.host_error(HostError.APPROVAL_RESOLVER_FAILED, type(e).__name__),
                     False,
                 )
 
@@ -828,9 +810,7 @@ class InterceptionEmitter:
         try:
             # §9: the resolver's verdict crosses the same §5 gate as an
             # interceptor's.
-            rv = Verdict.from_wire(
-                json.loads(_core.validate_verdict(dumps(res.verdict.to_wire())))
-            )
+            rv = Verdict.from_wire(json.loads(_core.validate_verdict(dumps(res.verdict.to_wire()))))
         except Exception as e:  # noqa: BLE001
             return Verdict.host_error(HostError.VERDICT_INVALID, str(e)), False
         # §9: outcome/decision must agree — approve MUST carry a permit,

--- a/sdk/python/python/agent_hooks/exceptions.py
+++ b/sdk/python/python/agent_hooks/exceptions.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """Exceptions a host raises to its caller when a hook blocks (§6)."""
+
 from __future__ import annotations
 
 from agent_hooks._types import InterceptionPoint, InterceptionRecord

--- a/sdk/python/python/agent_hooks/interceptor.py
+++ b/sdk/python/python/agent_hooks/interceptor.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """Interceptor protocol (§7)."""
+
 from __future__ import annotations
 
 from typing import Any, Protocol, runtime_checkable

--- a/sdk/python/python/agent_hooks/path.py
+++ b/sdk/python/python/agent_hooks/path.py
@@ -7,6 +7,7 @@ helpers remain pure-Python for callers that need segment introspection
 without a JSON round-trip; ``apply`` — the security-relevant path — goes
 through the core so behaviour is identical across SDKs.
 """
+
 from __future__ import annotations
 
 import json

--- a/sdk/python/tests/test_canonical.py
+++ b/sdk/python/tests/test_canonical.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """Unit tests for §10 canonical JSON and context identity."""
+
 from __future__ import annotations
 
 from agent_hooks import canonical_json, context_identity

--- a/sdk/python/tests/test_ctk_reference.py
+++ b/sdk/python/tests/test_ctk_reference.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """CTK self-test: run all vectors against the in-tree ReferenceHarness."""
+
 from __future__ import annotations
 
 import asyncio
@@ -32,9 +33,7 @@ def test_reference_harness_conformance(vector: dict) -> None:
             "EXPECTED_SKIPS only with a capability rationale"
         )
         pytest.skip(result.detail)
-    assert result.status == "pass", "\n" + "\n".join(
-        f"  - {f}" for f in result.failures
-    )
+    assert result.status == "pass", "\n" + "\n".join(f"  - {f}" for f in result.failures)
 
 
 def test_skip_set_matches_manifest() -> None:

--- a/sdk/python/tests/test_decided_by.py
+++ b/sdk/python/tests/test_decided_by.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """Unit tests for InterceptionRecord auditability fields (Q6)."""
+
 from __future__ import annotations
 
 import asyncio

--- a/sdk/python/tests/test_emitter_seams.py
+++ b/sdk/python/tests/test_emitter_seams.py
@@ -4,6 +4,7 @@
 approval redaction (§9), record sink + retention bound (§10.3), and the
 effective-target return from ``emit`` (§4.3).
 """
+
 from __future__ import annotations
 
 import asyncio

--- a/sdk/python/tests/test_golden_identity.py
+++ b/sdk/python/tests/test_golden_identity.py
@@ -6,6 +6,7 @@ Loads ``conformance/golden/identity.json`` (generated from the Rust core)
 and asserts the Python SDK — which delegates to the same core via PyO3 —
 produces identical output. This is the RM-N01/RM-N02 closure test.
 """
+
 from __future__ import annotations
 
 import json
@@ -14,9 +15,7 @@ import pathlib
 import pytest
 from agent_hooks import canonical_json, context_identity
 
-_GOLDEN = (
-    pathlib.Path(__file__).resolve().parents[3] / "conformance" / "golden" / "identity.json"
-)
+_GOLDEN = pathlib.Path(__file__).resolve().parents[3] / "conformance" / "golden" / "identity.json"
 _FIXTURES = json.loads(_GOLDEN.read_text())["fixtures"]
 
 

--- a/sdk/python/tests/test_path.py
+++ b/sdk/python/tests/test_path.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """Unit tests for §5.2 transform path grammar and application."""
+
 from __future__ import annotations
 
 import pytest

--- a/sdk/python/tests/test_profiles.py
+++ b/sdk/python/tests/test_profiles.py
@@ -7,6 +7,7 @@ run_all single-consult rule, parallel transform conflict, unanimous
 disagreement, the §4.4 NaN marshalling guard, the §10.1 provider seam
 (None/custom), and the §10.2 big-int rejection.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -201,9 +202,7 @@ def test_first_deny_resume_allows_multiple_consultations() -> None:
 
 
 def test_first_deny_reject_leaves_deny_standing() -> None:
-    approver = Approver(
-        ApprovalOutcome.REJECT, Verdict(decision=Decision.DENY, reason="rejected")
-    )
+    approver = Approver(ApprovalOutcome.REJECT, Verdict(decision=Decision.DENY, reason="rejected"))
     em = InterceptionEmitter(resolver=approver)
     em.register(Scripted(Verdict.escalate(reason="check")))
     r = _emit(em, _ctx())
@@ -294,9 +293,7 @@ def test_evaluate_only_never_consults_and_proceeds() -> None:
 
 
 def test_parallel_strictest_transform_conflict_fails_closed() -> None:
-    em = InterceptionEmitter(
-        composition=CompositionConfig.strictest(SynthesisPolicy.DENY)
-    )
+    em = InterceptionEmitter(composition=CompositionConfig.strictest(SynthesisPolicy.DENY))
     em.register(Scripted(_transform("$target.url", "a")))
     em.register(Scripted(_transform("$target.url", "b")))
     ctx = _ctx()
@@ -309,9 +306,7 @@ def test_parallel_strictest_transform_conflict_fails_closed() -> None:
 
 
 def test_parallel_strictest_conflict_approval_consults_seam() -> None:
-    approver = Approver(
-        ApprovalOutcome.APPROVE, _transform("$target.url", "resolved")
-    )
+    approver = Approver(ApprovalOutcome.APPROVE, _transform("$target.url", "resolved"))
     em = InterceptionEmitter(
         resolver=approver,
         composition=CompositionConfig.strictest(SynthesisPolicy.APPROVAL),
@@ -330,9 +325,7 @@ def test_parallel_strictest_conflict_approval_consults_seam() -> None:
 
 
 def test_parallel_strictest_single_transform_applies() -> None:
-    em = InterceptionEmitter(
-        composition=CompositionConfig.strictest(SynthesisPolicy.DENY)
-    )
+    em = InterceptionEmitter(composition=CompositionConfig.strictest(SynthesisPolicy.DENY))
     em.register(Scripted(Verdict(decision=Decision.ALLOW)))
     em.register(Scripted(_transform("$target.url", "safe")))
     ctx = _ctx()
@@ -367,9 +360,7 @@ def test_parallel_strictest_isolated_snapshots() -> None:
 
 def test_parallel_strictest_liftable_winner_consults() -> None:
     approver = Approver(ApprovalOutcome.APPROVE, Verdict(decision=Decision.ALLOW))
-    em = InterceptionEmitter(
-        resolver=approver, composition=CompositionConfig.strictest()
-    )
+    em = InterceptionEmitter(resolver=approver, composition=CompositionConfig.strictest())
     em.register(Scripted(Verdict(decision=Decision.ALLOW)))
     em.register(Scripted(Verdict.escalate(reason="check")))
     r = _emit(em, _ctx())
@@ -395,9 +386,7 @@ def test_unanimous_allow_passes_with_unions() -> None:
 
 def test_unanimous_disagreement_synthesizes_deny() -> None:
     em = InterceptionEmitter(
-        composition=CompositionConfig.unanimous(
-            SynthesisPolicy.DENY, SynthesisPolicy.DENY
-        )
+        composition=CompositionConfig.unanimous(SynthesisPolicy.DENY, SynthesisPolicy.DENY)
     )
     em.register(Scripted(Verdict(decision=Decision.ALLOW)))
     em.register(Scripted(_transform("$target.url", "x")))
@@ -413,9 +402,7 @@ def test_unanimous_disagreement_approval_consults_seam() -> None:
     approver = Approver(ApprovalOutcome.APPROVE, Verdict(decision=Decision.ALLOW))
     em = InterceptionEmitter(
         resolver=approver,
-        composition=CompositionConfig.unanimous(
-            SynthesisPolicy.APPROVAL, SynthesisPolicy.DENY
-        ),
+        composition=CompositionConfig.unanimous(SynthesisPolicy.APPROVAL, SynthesisPolicy.DENY),
     )
     em.register(Scripted(Verdict(decision=Decision.ALLOW)))
     em.register(Scripted(_deny()))
@@ -428,9 +415,7 @@ def test_unanimous_disagreement_approval_consults_seam() -> None:
 
 def test_unanimous_disagreement_approval_without_resolver_stands() -> None:
     em = InterceptionEmitter(
-        composition=CompositionConfig.unanimous(
-            SynthesisPolicy.APPROVAL, SynthesisPolicy.DENY
-        )
+        composition=CompositionConfig.unanimous(SynthesisPolicy.APPROVAL, SynthesisPolicy.DENY)
     )
     em.register(Scripted(Verdict(decision=Decision.ALLOW)))
     em.register(Scripted(_deny()))
@@ -460,9 +445,7 @@ def test_custom_provider_identities_and_name() -> None:
         calls.append(ctx["interception_point"])
         return f"host:{ctx['sequence']}"
 
-    em = InterceptionEmitter(
-        identity_provider=IdentityProvider("host-hash", fingerprint)
-    )
+    em = InterceptionEmitter(identity_provider=IdentityProvider("host-hash", fingerprint))
     em.register(Scripted(Verdict(decision=Decision.ALLOW)))
     r = _emit(em, _ctx())
     assert r.identity_provider == "host-hash"

--- a/sdk/python/tests/test_record_semantics.py
+++ b/sdk/python/tests/test_record_semantics.py
@@ -39,8 +39,8 @@ class Allow:
 
 
 def _emit(em: InterceptionEmitter, ctx: dict[str, Any]):
-    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
-        em.emit_unchecked(ctx)
+    return (
+        asyncio.get_event_loop_policy().new_event_loop().run_until_complete(em.emit_unchecked(ctx))
     )
 
 

--- a/sdk/python/tests/test_timeouts.py
+++ b/sdk/python/tests/test_timeouts.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """§7 interceptor/resolver timeout enforcement (NOW-09)."""
+
 from __future__ import annotations
 
 import asyncio

--- a/sdk/python/tests/test_types.py
+++ b/sdk/python/tests/test_types.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """Unit tests for §5 verdict validation and §3 interception-point properties."""
+
 from __future__ import annotations
 
 import pytest
@@ -109,9 +110,7 @@ class TestVerdict:
         with pytest.raises(ValueError):
             Verdict.from_wire({"decision": "allow", "warnings": ["x"]})
         with pytest.raises(ValueError):
-            Verdict.from_wire(
-                {"decision": "allow", "warnings": [{"reason": "host_error:x"}]}
-            )
+            Verdict.from_wire({"decision": "allow", "warnings": [{"reason": "host_error:x"}]})
 
     def test_from_wire_rejects_approval_on_permit(self) -> None:
         with pytest.raises(ValueError):

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -14,6 +14,7 @@ name = "agent-hooks-sdk"
 version = "0.1.0-alpha.2"
 dependencies = [
  "async-trait",
+ "criterion",
  "futures-util",
  "proptest",
  "ryu-js",
@@ -23,6 +24,27 @@ dependencies = [
  "thiserror",
  "tokio",
 ]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "async-trait"
@@ -72,10 +94,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "const-oid"
@@ -91,6 +171,46 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -111,6 +231,12 @@ dependencies = [
  "const-oid",
  "crypto-common",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "errno"
@@ -182,12 +308,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -228,6 +391,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "pin-project-lite"
@@ -338,6 +507,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +565,15 @@ name = "ryu-js"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
@@ -479,6 +680,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,12 +738,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/sdk/rust/core/Cargo.toml
+++ b/sdk/rust/core/Cargo.toml
@@ -28,6 +28,11 @@ tokio = { version = "1", features = ["time"], optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "time"] }
 proptest = "1"
+criterion = { version = "0.5", default-features = false }
+
+[[bench]]
+name = "emission"
+harness = false
 
 [features]
 default = []

--- a/sdk/rust/core/benches/emission.rs
+++ b/sdk/rust/core/benches/emission.rs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//! Latency benchmarks for the per-emission critical path (NEXT-19).
+//! Budget published in ARCHITECTURE.md; run with `cargo bench -p
+//! agent-hooks-sdk`.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use serde_json::{json, Value};
+
+fn ctx_of(payload_bytes: usize) -> agent_hooks::AgentContext {
+    let blob = "x".repeat(payload_bytes);
+    json!({
+        "spec": "agent-hooks/0.1",
+        "interception_point": "pre_tool_call",
+        "timestamp": "2026-01-01T00:00:00Z",
+        "sequence": 1,
+        "agent": {"id": "a", "framework": "bench"},
+        "session": {"id": "s"},
+        "tool_call": {"id": "tc", "name": "t", "args": {"blob": blob}},
+        "target": {"blob": blob}
+    })
+    .as_object()
+    .unwrap()
+    .clone()
+}
+
+fn bench_identity(c: &mut Criterion) {
+    let mut g = c.benchmark_group("context_identity");
+    for kb in [1usize, 100, 1024] {
+        let ctx = ctx_of(kb * 1024);
+        g.bench_with_input(
+            BenchmarkId::from_parameter(format!("{kb}KiB")),
+            &ctx,
+            |b, ctx| b.iter(|| agent_hooks::context_identity(std::hint::black_box(ctx)).unwrap()),
+        );
+    }
+    g.finish();
+}
+
+fn bench_compose(c: &mut Criterion) {
+    let mut g = c.benchmark_group("compose_aggregate");
+    for n in [1usize, 5, 10] {
+        let verdicts: Vec<Value> = (0..n).map(|_| json!({"decision": "allow"})).collect();
+        let composition = json!({"profile": "parallel/strictest"}).to_string();
+        let verdicts_json = Value::Array(verdicts).to_string();
+        g.bench_with_input(
+            BenchmarkId::from_parameter(format!("{n}-interceptors")),
+            &(composition, verdicts_json),
+            |b, (comp, verd)| {
+                b.iter(|| {
+                    agent_hooks::ffi_surface::compose_aggregate(
+                        std::hint::black_box(comp),
+                        std::hint::black_box(verd),
+                    )
+                    .unwrap()
+                })
+            },
+        );
+    }
+    g.finish();
+}
+
+fn bench_emit(c: &mut Criterion) {
+    use agent_hooks::{AgentContext, EnforcementMode, InterceptionEmitter, Interceptor, Verdict};
+    struct Allow;
+    #[async_trait::async_trait]
+    impl Interceptor for Allow {
+        async fn intercept(&self, _ctx: &AgentContext) -> Verdict {
+            Verdict::allow()
+        }
+    }
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+    let mut g = c.benchmark_group("emit_allow_path");
+    for (kb, n) in [(1usize, 1usize), (100, 5), (1024, 10)] {
+        g.bench_function(BenchmarkId::from_parameter(format!("{kb}KiB-{n}i")), |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let mut e = InterceptionEmitter::new(EnforcementMode::Enforce, None);
+                    for _ in 0..n {
+                        e.register(Box::new(Allow));
+                    }
+                    let mut ctx = ctx_of(kb * 1024);
+                    e.emit_unchecked(std::hint::black_box(&mut ctx)).await
+                })
+            })
+        });
+    }
+    g.finish();
+}
+
+criterion_group!(benches, bench_identity, bench_compose, bench_emit);
+criterion_main!(benches);

--- a/sdk/rust/core/src/builder.rs
+++ b/sdk/rust/core/src/builder.rs
@@ -208,7 +208,15 @@ mod tests {
         let c1 = b.input(serde_json::json!("hi"), "user");
         assert_eq!(c0["sequence"], 0);
         assert_eq!(c1["sequence"], 1);
-        for k in ["spec", "interception_point", "timestamp", "sequence", "agent", "session", "target"] {
+        for k in [
+            "spec",
+            "interception_point",
+            "timestamp",
+            "sequence",
+            "agent",
+            "session",
+            "target",
+        ] {
             assert!(c1.contains_key(k), "missing {k}");
         }
         assert_eq!(c1["input"]["role"], "user");

--- a/sdk/rust/core/src/canonical.rs
+++ b/sdk/rust/core/src/canonical.rs
@@ -20,8 +20,8 @@
 //! Non-finite numbers and lone surrogates fail at the parse funnel
 //! before this module runs.
 
-use crate::types::{AgentContext, HostError};
 use crate::jcs;
+use crate::types::{AgentContext, HostError};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::fmt::Write;
@@ -103,7 +103,11 @@ pub fn scan_raw_integer_domain(text: &str) -> Result<(), (HostError, String)> {
                 }
                 if integer_syntax {
                     let digits = &b[start..i];
-                    let digits = if digits.first() == Some(&b'-') { &digits[1..] } else { digits };
+                    let digits = if digits.first() == Some(&b'-') {
+                        &digits[1..]
+                    } else {
+                        digits
+                    };
                     let over = digits.len() > LIMIT.len()
                         || (digits.len() == LIMIT.len() && digits > LIMIT);
                     if over {
@@ -152,7 +156,10 @@ fn conditional_for(ip: &str) -> &'static [Keep] {
         "pre_model_call" => &[("model", Some(&["id"])), ("messages", None)],
         "post_model_call" => &[
             ("model", Some(&["id"])),
-            ("response", Some(&["content", "tool_calls", "finish_reason"])),
+            (
+                "response",
+                Some(&["content", "tool_calls", "finish_reason"]),
+            ),
         ],
         "pre_tool_call" => &[("tool_call", Some(&["id", "name", "args"]))],
         "post_tool_call" => &[
@@ -335,13 +342,21 @@ pub fn validate_envelope(ctx: &AgentContext) -> Result<(), (HostError, String)> 
     if ctx.get("timestamp").and_then(Value::as_str).is_none() {
         return err("timestamp", "a string");
     }
-    if !ctx.get("sequence").and_then(Value::as_i64).is_some_and(|n| n >= 0) {
+    if !ctx
+        .get("sequence")
+        .and_then(Value::as_i64)
+        .is_some_and(|n| n >= 0)
+    {
         return err("sequence", "an integer >= 0");
     }
     let agent = ctx.get("agent").and_then(Value::as_object);
     match agent {
         Some(a) => {
-            if !a.get("id").and_then(Value::as_str).is_some_and(|v| !v.is_empty()) {
+            if !a
+                .get("id")
+                .and_then(Value::as_str)
+                .is_some_and(|v| !v.is_empty())
+            {
                 return err("agent.id", "a non-empty string");
             }
             let fw_ok = a.get("framework").and_then(Value::as_str).is_some_and(|v| {
@@ -469,10 +484,26 @@ mod tests {
         .clone();
         let mut bare = ctx.clone();
         // Remove every nested optional field; identity must be unchanged.
-        bare.get_mut("tool_result").unwrap().as_object_mut().unwrap().remove("duration_ms");
-        bare.get_mut("tool_call").unwrap().as_object_mut().unwrap().remove("content_hash");
-        bare.get_mut("agent").unwrap().as_object_mut().unwrap().remove("name");
-        bare.get_mut("session").unwrap().as_object_mut().unwrap().remove("turn");
+        bare.get_mut("tool_result")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .remove("duration_ms");
+        bare.get_mut("tool_call")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .remove("content_hash");
+        bare.get_mut("agent")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .remove("name");
+        bare.get_mut("session")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .remove("turn");
         assert_eq!(
             context_identity(&ctx).unwrap(),
             context_identity(&bare).unwrap()
@@ -485,7 +516,10 @@ mod tests {
         let c = ctx(json!({"id": 9_007_199_254_740_993_i64}));
         let (e, detail) = context_identity(&c).unwrap_err();
         assert_eq!(e, HostError::ContextInvalid);
-        assert!(detail.contains("string-encode 64-bit identifiers"), "{detail}");
+        assert!(
+            detail.contains("string-encode 64-bit identifiers"),
+            "{detail}"
+        );
 
         let c = ctx(json!({"id": -9_007_199_254_740_993_i64}));
         assert!(context_identity(&c).is_err());
@@ -510,7 +544,10 @@ mod tests {
         // big integer in an optional field never reaches JCS, so it
         // must not reject.
         let mut c = ctx(json!({"ok": 1}));
-        c.insert("extensions".into(), json!({"host": {"big": 9_007_199_254_740_993_i64}}));
+        c.insert(
+            "extensions".into(),
+            json!({"host": {"big": 9_007_199_254_740_993_i64}}),
+        );
         assert!(context_identity(&c).is_ok());
     }
 
@@ -541,7 +578,10 @@ mod tests {
         assert!(scan_raw_integer_domain(r#"{"x":9007199254740993}"#).is_err());
         assert!(scan_raw_integer_domain(r#"{"x":-9007199254740991}"#).is_ok());
         // Digits inside strings (including escapes) are not numbers.
-        assert!(scan_raw_integer_domain(r#"{"x":"18446744073709551616","y":"a\"18446744073709551616"}"#).is_ok());
+        assert!(scan_raw_integer_domain(
+            r#"{"x":"18446744073709551616","y":"a\"18446744073709551616"}"#
+        )
+        .is_ok());
     }
 
     #[test]
@@ -599,8 +639,15 @@ mod tests {
 
         // Missing required subfield.
         let mut c = good.clone();
-        c.get_mut("tool_call").unwrap().as_object_mut().unwrap().remove("name");
-        assert!(validate_envelope(&c).unwrap_err().1.contains("tool_call.name"));
+        c.get_mut("tool_call")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .remove("name");
+        assert!(validate_envelope(&c)
+            .unwrap_err()
+            .1
+            .contains("tool_call.name"));
 
         // Unknown interception point.
         let mut c = good.clone();
@@ -615,7 +662,11 @@ mod tests {
         c.remove("session");
         assert!(validate_envelope(&c).is_err());
         let mut c = good.clone();
-        c.get_mut("agent").unwrap().as_object_mut().unwrap().insert("framework".into(), json!("Bad Framework"));
+        c.get_mut("agent")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .insert("framework".into(), json!("Bad Framework"));
         assert!(validate_envelope(&c).is_err());
         let mut c = good.clone();
         c.insert("spec".into(), json!("agent-hooks/x.1"));
@@ -640,5 +691,4 @@ mod tests {
         c.remove("interception_point");
         assert!(context_identity(&c).is_err());
     }
-
 }

--- a/sdk/rust/core/src/composition.rs
+++ b/sdk/rust/core/src/composition.rs
@@ -107,7 +107,8 @@ impl CompositionConfig {
             P::ParallelStrictest => {
                 self.on_approval = None;
                 self.on_disagreement = None;
-                self.on_transform_conflict.get_or_insert(SynthesisPolicy::Deny);
+                self.on_transform_conflict
+                    .get_or_insert(SynthesisPolicy::Deny);
             }
             P::ParallelUnanimous => {
                 self.on_approval = None;
@@ -374,7 +375,10 @@ mod tests {
             Verdict::escalate(None, None),
             Verdict::allow()
         ]));
-        assert!(!all_denies_liftable(&[Verdict::escalate(None, None), deny()]));
+        assert!(!all_denies_liftable(&[
+            Verdict::escalate(None, None),
+            deny()
+        ]));
     }
 
     #[test]

--- a/sdk/rust/core/src/ctk.rs
+++ b/sdk/rust/core/src/ctk.rs
@@ -76,7 +76,9 @@ impl Interceptor for ScriptedInterceptor {
     async fn intercept(&self, context: &AgentContext) -> Verdict {
         let ctx_value = Value::Object(context.clone());
         if let Some(rec) = &self.recorded {
-            rec.lock().expect("recorder poisoned").push(ctx_value.clone());
+            rec.lock()
+                .expect("recorder poisoned")
+                .push(ctx_value.clone());
         }
         let wire = scripted_intercept(&self.rules, &ctx_value);
         // §7 isolation fault (TM-05): the trait takes &AgentContext, so
@@ -127,9 +129,9 @@ impl ApprovalResolver for ScriptedResolver {
             Some("reject") => crate::ApprovalOutcome::Reject,
             _ => crate::ApprovalOutcome::Unresolved,
         };
-        let verdict = out.get("verdict").map(|v| {
-            crate::verdict_from_wire(v).expect("malformed approval_script verdict")
-        });
+        let verdict = out
+            .get("verdict")
+            .map(|v| crate::verdict_from_wire(v).expect("malformed approval_script verdict"));
         let echoed = out["context_identity"].as_str().unwrap_or_default();
         ApprovalResolution {
             outcome,
@@ -254,11 +256,10 @@ pub async fn run_vector(harness: &mut dyn Harness, vector: &Value) -> VectorResu
     // provider-failure rule: deny context_invalid before dispatch).
     let identity_provider = match vector.get("identity_provider") {
         Some(Value::Null) => IdentityProvider::Null,
-        Some(Value::String(s)) if s == "ctk-fault" => IdentityProvider::custom(
-            "ctk-fault",
-            |_| panic!("ctk scripted provider fault"),
-        )
-        .expect("ctk-fault satisfies the name rules"),
+        Some(Value::String(s)) if s == "ctk-fault" => {
+            IdentityProvider::custom("ctk-fault", |_| panic!("ctk scripted provider fault"))
+                .expect("ctk-fault satisfies the name rules")
+        }
         _ => IdentityProvider::JcsSha256,
     };
 
@@ -307,7 +308,10 @@ impl ReferenceHarness {
     }
 
     fn invoke_tool(&self, name: &str, args: &Value) -> (Value, bool) {
-        let tools = self.scenario["tools"].as_array().cloned().unwrap_or_default();
+        let tools = self.scenario["tools"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
         let spec = tools
             .iter()
             .find(|t| t["name"].as_str() == Some(name))
@@ -408,11 +412,7 @@ impl ReferenceHarness {
         }
 
         if !final_output.is_null() {
-            let mut ctx = self
-                .builder
-                .as_mut()
-                .expect("setup")
-                .output(final_output);
+            let mut ctx = self.builder.as_mut().expect("setup").output(final_output);
             self.emitter.as_mut().expect("setup").emit(&mut ctx).await?;
             final_output = ctx["output"]["content"].clone();
         }
@@ -422,11 +422,11 @@ impl ReferenceHarness {
     async fn do_tool_call(&mut self, tc: &Value) -> Result<Value, InterceptionBlocked> {
         let id = tc["id"].as_str().unwrap_or("").to_owned();
         let name = tc["name"].as_str().unwrap_or("").to_owned();
-        let mut ctx = self
-            .builder
-            .as_mut()
-            .expect("setup")
-            .pre_tool_call(&id, &name, tc["args"].clone());
+        let mut ctx =
+            self.builder
+                .as_mut()
+                .expect("setup")
+                .pre_tool_call(&id, &name, tc["args"].clone());
         self.emitter.as_mut().expect("setup").emit(&mut ctx).await?;
         let args = ctx["tool_call"]["args"].clone(); // post-transform (§4.3)
 
@@ -458,7 +458,11 @@ impl Harness for ReferenceHarness {
         // is exercised by unit tests instead).
         // int64_json: Rust holds i64, so vectors carrying >2^53
         // integers load losslessly (§4.4; JS harnesses omit this).
-        vec!["model_calls".into(), "tool_calls".into(), "int64_json".into()]
+        vec![
+            "model_calls".into(),
+            "tool_calls".into(),
+            "int64_json".into(),
+        ]
     }
 
     fn setup(&mut self, setup: VectorSetup) {
@@ -505,13 +509,15 @@ impl Harness for ReferenceHarness {
             Err(_) => ("blocked", Value::Null),
         };
 
-        let mut ctx = self.builder.as_mut().expect("setup").agent_shutdown(
-            if outcome == "completed" {
-                "completed"
-            } else {
-                "error"
-            },
-        );
+        let mut ctx =
+            self.builder
+                .as_mut()
+                .expect("setup")
+                .agent_shutdown(if outcome == "completed" {
+                    "completed"
+                } else {
+                    "error"
+                });
         let emitter = self.emitter.as_mut().expect("setup");
         emitter.emit_unchecked(&mut ctx).await;
 

--- a/sdk/rust/core/src/ctk_engine.rs
+++ b/sdk/rust/core/src/ctk_engine.rs
@@ -91,9 +91,7 @@ pub fn scripted_intercept(rules: &[Value], ctx: &Value) -> Value {
             match rule.get("fault").and_then(Value::as_str) {
                 Some("raise") => return serde_json::json!({"__ctk_fault__": "raise"}),
                 // §5-invalid shape: transform decision with no body.
-                Some("malformed_verdict") => {
-                    return serde_json::json!({"decision": "transform"})
-                }
+                Some("malformed_verdict") => return serde_json::json!({"decision": "transform"}),
                 // §7 isolation (TM-05): the wrapper mutates the context
                 // object it received in-place, then returns allow; the
                 // vector asserts enforcement, identity, and sibling
@@ -225,7 +223,10 @@ fn validate_required(ctx: &Value, failures: &mut Vec<String>) {
 }
 
 fn assert_interceptions(expect: &Value, recorded: &[Value], failures: &mut Vec<String>) {
-    let expected = expect["interceptions"].as_array().cloned().unwrap_or_default();
+    let expected = expect["interceptions"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
     let strict = expect
         .get("sequence_strict")
         .and_then(Value::as_bool)
@@ -252,8 +253,7 @@ fn assert_interceptions(expect: &Value, recorded: &[Value], failures: &mut Vec<S
         let mut ri = 0usize;
         for e in &expected {
             let want = e.get(IP).and_then(Value::as_str).unwrap_or("");
-            while ri < recorded.len()
-                && recorded[ri].get(IP).and_then(Value::as_str) != Some(want)
+            while ri < recorded.len() && recorded[ri].get(IP).and_then(Value::as_str) != Some(want)
             {
                 ri += 1;
             }
@@ -345,9 +345,8 @@ fn assert_identities(expect: &Value, rr: &RunRecord, failures: &mut Vec<String>)
         return;
     };
     if rr.identities.is_empty() {
-        failures.push(
-            "expect.identities_equal is set but harness did not report identities".into(),
-        );
+        failures
+            .push("expect.identities_equal is set but harness did not report identities".into());
         return;
     }
     let all_equal = rr
@@ -395,7 +394,9 @@ fn assert_records(expect: &Value, rr: &RunRecord, failures: &mut Vec<String>) {
             ri += 1;
         }
         if ri >= rr.records.len() {
-            failures.push(format!("expected record for {want_ip:?} not found in order"));
+            failures.push(format!(
+                "expected record for {want_ip:?} not found in order"
+            ));
             return;
         }
         let rec = &rr.records[ri];

--- a/sdk/rust/core/src/emitter.rs
+++ b/sdk/rust/core/src/emitter.rs
@@ -105,7 +105,10 @@ impl IdentityProvider {
     ) -> Result<Self, (HostError, String)> {
         let name = name.into();
         crate::types::validate_provider_name(&name)?;
-        Ok(Self::Custom { name, f: Box::new(f) })
+        Ok(Self::Custom {
+            name,
+            f: Box::new(f),
+        })
     }
 }
 
@@ -140,8 +143,6 @@ impl IdentityProvider {
         }
     }
 }
-
-
 
 /// §6.3/§7: invoke one interceptor with panic isolation and (with the
 /// `tokio-timeout` feature) the emitter-owned timeout. `Err` carries a
@@ -265,6 +266,13 @@ impl InterceptionEmitter {
     }
 
     /// Declare the composition profile for subsequent emissions (§7.1).
+    ///
+    /// The default (`sequential/first_deny`, `on_approval: stop`) is
+    /// the configuration §14 warns about: after an approval lifts a
+    /// liftable deny, interceptors registered after the escalating one
+    /// never run for that emission (`fold_truncated` on the record).
+    /// Register must-run controls first, or use `sequential/run_all` /
+    /// a parallel profile. See docs/PRODUCTION.md.
     pub fn set_composition(&mut self, composition: CompositionConfig) -> &mut Self {
         self.composition = composition;
         self
@@ -398,9 +406,7 @@ impl InterceptionEmitter {
                 // §10.1/§10.2: the provider rejected the value domain,
                 // raised, or panicked. Fail closed before any
                 // interceptor runs.
-                Err((e, detail)) => {
-                    (None, Some(DispatchOutcome::synthesized(e, Some(detail))))
-                }
+                Err((e, detail)) => (None, Some(DispatchOutcome::synthesized(e, Some(detail)))),
             }
         };
         let outcome = match outcome {
@@ -421,6 +427,19 @@ impl InterceptionEmitter {
             // the raw-text coercion class (Number has no beyond-u64
             // form); the in-memory check inside finalize is complete.
             jcs_input_rejected: false,
+            // §10.3/NEXT-19: reuse input_identity when the context
+            // bytes cannot have changed — evaluate_only never applies
+            // transforms (§8); in enforce mode, no transform anywhere
+            // in the dispatch (including a substituted resolution)
+            // means no fold mutated the context. Conservative: any
+            // transform or substitution forces a fresh computation.
+            unchanged_since_input: self.mode == EnforcementMode::EvaluateOnly
+                || (outcome.resolved_by.is_none()
+                    && outcome.combined.decision != Decision::Transform
+                    && outcome
+                        .verdicts
+                        .iter()
+                        .all(|v| v.decision != Decision::Transform)),
             decided_by: outcome.decided_by,
             composition: self.composition,
             verdicts: outcome.verdicts,
@@ -481,12 +500,14 @@ impl InterceptionEmitter {
 
         for (i, interceptor) in self.interceptors.iter().enumerate() {
             let idx = i as u32;
-            // §7: each interceptor gets its own copy — in-place mutation
-            // of the copy cannot alter enforcement.
+            // §7: isolation is the `&AgentContext` borrow itself — the
+            // interceptor cannot mutate through it, so no defensive
+            // clone is needed (NEXT-19: this was one full deep copy per
+            // interceptor per emission).
             // §5 gate on the interceptor's own return; host-synthesized
             // failure substitutions (Err) bypass it (TM-02 is about
             // interceptor spoofing, not host substitution).
-            let v = match call_isolated(interceptor.as_ref(), &ctx.clone(), self.timeout).await {
+            let v = match call_isolated(interceptor.as_ref(), &*ctx, self.timeout).await {
                 Ok(v) if v.validate().is_err() => {
                     Verdict::host_error(HostError::VerdictInvalid, None)
                 }
@@ -624,7 +645,7 @@ impl InterceptionEmitter {
             // §6.3 per-interceptor: a malformed verdict becomes that
             // interceptor's synthesized deny; the rest still run.
             // Host-synthesized substitutions (Err) bypass the §5 gate.
-            let v = match call_isolated(interceptor.as_ref(), &ctx.clone(), self.timeout).await {
+            let v = match call_isolated(interceptor.as_ref(), &*ctx, self.timeout).await {
                 Ok(v) if v.validate().is_err() => {
                     Verdict::host_error(HostError::VerdictInvalid, None)
                 }
@@ -723,9 +744,7 @@ impl InterceptionEmitter {
                         // A liftable winner implies no plain deny exists
                         // (severity), so the §7.4 "every deny is
                         // liftable" consult precondition holds.
-                        debug_assert!(
-                            !winner.is_liftable() || all_denies_liftable(&all)
-                        );
+                        debug_assert!(!winner.is_liftable() || all_denies_liftable(&all));
                         match self.consult(ctx, &winner).await {
                             Consultation::NotConsulted => DispatchOutcome {
                                 combined: with_unions(winner, &all),
@@ -739,7 +758,8 @@ impl InterceptionEmitter {
                                 // §10.3: any consultation is recorded — permit
                                 // substitution as "approval", everything else as
                                 // "rejection".
-                                resolved_by = Some(if permitted { "approval" } else { "rejection" });
+                                resolved_by =
+                                    Some(if permitted { "approval" } else { "rejection" });
                                 let synthesized = is_host_synthesized(&verdict);
                                 let combined = if permitted {
                                     resolved_by = Some("approval");
@@ -864,9 +884,7 @@ impl InterceptionEmitter {
         resolved_by: &mut Option<&'static str>,
     ) -> Verdict {
         match policy {
-            SynthesisPolicy::Deny => {
-                with_unions(Verdict::host_error(err, Some(detail)), pool)
-            }
+            SynthesisPolicy::Deny => with_unions(Verdict::host_error(err, Some(detail)), pool),
             SynthesisPolicy::Approval => {
                 let liftable = Verdict::host_error_liftable(err, Some(detail));
                 match self.consult(ctx, &liftable).await {
@@ -942,8 +960,7 @@ impl InterceptionEmitter {
         let redacted;
         let presented: &AgentContext = match &self.approval_redactor {
             Some(f) => {
-                redacted = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(ctx)))
-                {
+                redacted = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(ctx))) {
                     Ok(c) => c,
                     Err(_) => {
                         return Consultation::Substituted {
@@ -1088,13 +1105,19 @@ mod tests {
     fn transform(path: &str, value: serde_json::Value) -> Verdict {
         Verdict {
             decision: Decision::Transform,
-            transform: Some(Transform { path: path.into(), value }),
+            transform: Some(Transform {
+                path: path.into(),
+                value,
+            }),
             ..Verdict::allow()
         }
     }
 
     fn deny() -> Verdict {
-        Verdict { decision: Decision::Deny, ..Verdict::allow() }
+        Verdict {
+            decision: Decision::Deny,
+            ..Verdict::allow()
+        }
     }
 
     #[tokio::test]
@@ -1165,7 +1188,10 @@ mod tests {
     #[tokio::test]
     async fn first_deny_no_resolver_deny_stands_without_error() {
         let mut e = InterceptionEmitter::new(EnforcementMode::Enforce, None);
-        e.register(Box::new(Scripted(Verdict::escalate(Some("check".into()), None))));
+        e.register(Box::new(Scripted(Verdict::escalate(
+            Some("check".into()),
+            None,
+        ))));
         let mut c = ctx();
         let r = e.emit_unchecked(&mut c).await;
         // §9: no resolver → the liftable deny stands, NOT an error.
@@ -1179,7 +1205,10 @@ mod tests {
     async fn first_deny_stop_truncates_and_records_substitution() {
         let mut e = InterceptionEmitter::new(
             EnforcementMode::Enforce,
-            Some(Box::new(Approver(ApprovalOutcome::Approve, Verdict::allow()))),
+            Some(Box::new(Approver(
+                ApprovalOutcome::Approve,
+                Verdict::allow(),
+            ))),
         );
         e.set_composition(CompositionConfig::first_deny(OnApproval::Stop));
         e.register(Box::new(Scripted(Verdict::escalate(None, None))));
@@ -1196,7 +1225,10 @@ mod tests {
     async fn first_deny_resume_continues_the_fold() {
         let mut e = InterceptionEmitter::new(
             EnforcementMode::Enforce,
-            Some(Box::new(Approver(ApprovalOutcome::Approve, Verdict::allow()))),
+            Some(Box::new(Approver(
+                ApprovalOutcome::Approve,
+                Verdict::allow(),
+            ))),
         );
         e.set_composition(CompositionConfig::first_deny(OnApproval::Resume));
         e.register(Box::new(Scripted(Verdict::escalate(None, None))));
@@ -1255,7 +1287,12 @@ mod tests {
             r.verdict.reason.as_deref(),
             Some("host_error:context_invalid")
         );
-        assert!(r.verdict.message.as_deref().unwrap().contains("string-encode"));
+        assert!(r
+            .verdict
+            .message
+            .as_deref()
+            .unwrap()
+            .contains("string-encode"));
         assert!(r.verdicts.is_empty(), "no interceptor ran");
     }
 
@@ -1263,7 +1300,10 @@ mod tests {
     async fn shutdown_never_consults() {
         let mut e = InterceptionEmitter::new(
             EnforcementMode::Enforce,
-            Some(Box::new(Approver(ApprovalOutcome::Approve, Verdict::allow()))),
+            Some(Box::new(Approver(
+                ApprovalOutcome::Approve,
+                Verdict::allow(),
+            ))),
         );
         e.register(Box::new(Scripted(Verdict::escalate(None, None))));
         let mut c = ctx();
@@ -1320,8 +1360,16 @@ mod tests {
         e.register(Box::new(Panics));
         let r = e.emit_unchecked(&mut ctx()).await;
         assert!(!r.proceeds());
-        assert_eq!(r.verdict.reason.as_deref(), Some("host_error:interceptor_failed"));
-        assert!(!r.verdict.message.as_deref().unwrap_or("").contains("SECRET"));
+        assert_eq!(
+            r.verdict.reason.as_deref(),
+            Some("host_error:interceptor_failed")
+        );
+        assert!(!r
+            .verdict
+            .message
+            .as_deref()
+            .unwrap_or("")
+            .contains("SECRET"));
     }
 
     #[cfg(feature = "tokio-timeout")]
@@ -1339,7 +1387,10 @@ mod tests {
         e.set_timeout(std::time::Duration::from_millis(20));
         e.register(Box::new(Slow));
         let r = e.emit_unchecked(&mut ctx()).await;
-        assert_eq!(r.verdict.reason.as_deref(), Some("host_error:interceptor_timeout"));
+        assert_eq!(
+            r.verdict.reason.as_deref(),
+            Some("host_error:interceptor_timeout")
+        );
         assert_eq!(r.verdict.decision, Decision::Deny);
     }
 
@@ -1399,8 +1450,10 @@ mod tests {
                 self.0.resolve(req).await
             }
         }
-        let mut e =
-            InterceptionEmitter::new(EnforcementMode::Enforce, Some(Box::new(Shared(captured.clone()))));
+        let mut e = InterceptionEmitter::new(
+            EnforcementMode::Enforce,
+            Some(Box::new(Shared(captured.clone()))),
+        );
         e.register(Box::new(Escalates));
         e.set_approval_redactor(|ctx| {
             let mut c = ctx.clone();
@@ -1413,11 +1466,13 @@ mod tests {
         let r = e.emit_unchecked(&mut ctx()).await;
         assert!(r.proceeds());
         let (identity, presented) = captured.0.lock().unwrap().clone().unwrap();
-        assert!(!presented.contains("evil"), "unredacted content egressed: {presented}");
+        assert!(
+            !presented.contains("evil"),
+            "unredacted content egressed: {presented}"
+        );
         // The echoed identity matched what the emitter computed over
         // the redacted context (approve succeeded), and differs from
         // the record's own (unredacted) identities.
         assert_ne!(Some(identity.as_str()), r.input_identity.as_deref());
     }
-
 }

--- a/sdk/rust/core/src/enforce.rs
+++ b/sdk/rust/core/src/enforce.rs
@@ -97,6 +97,13 @@ pub struct FinalizeMeta {
     /// declared provider name with `null` identities — the §10.3
     /// rejection shape.
     pub jcs_input_rejected: bool,
+    /// True when no transform was applied to the context after
+    /// `input_identity` was computed (allow paths, evaluate_only): the
+    /// bytes are unchanged, so the JCS arm reuses `input_identity`
+    /// instead of re-canonicalizing and re-hashing the full payload
+    /// (NEXT-19). Defaults to `false` (compute — the safe direction);
+    /// only set by emitters that track fold state.
+    pub unchanged_since_input: bool,
     pub decided_by: Option<u32>,
     pub composition: CompositionConfig,
     /// Per-interceptor summaries (multi-verdict profiles, §10.3).
@@ -210,6 +217,14 @@ pub fn finalize(
             }
             None
         }
+        // §10.3: with no fold-applied transform the post-composition
+        // bytes are the pre-dispatch bytes — reuse the already-computed
+        // input identity (skips a full canonicalize+hash on the
+        // allow path). Only when the input identity exists: a None
+        // input with a declared jcs provider is the rejection shape.
+        Some(JCS_SHA256) if meta.unchanged_since_input && meta.input_identity.is_some() => {
+            meta.input_identity.clone()
+        }
         Some(JCS_SHA256) => match context_identity(ctx) {
             Ok(id) => Some(id),
             // §10.2/§10.3: the post-fold context left the provider's
@@ -228,7 +243,11 @@ pub fn finalize(
         Some(_) => meta.enforced_identity,
         None => None,
     };
-    let input_identity = if envelope_invalid.is_some() { None } else { meta.input_identity };
+    let input_identity = if envelope_invalid.is_some() {
+        None
+    } else {
+        meta.input_identity
+    };
     InterceptionRecord {
         interception_point: ip,
         mode,
@@ -317,7 +336,12 @@ mod tests {
     #[test]
     fn allow_identities_equal() {
         let c = ctx("pre_tool_call", json!({"url": "x"}));
-        let r = finalize(&c, Verdict::allow(), EnforcementMode::Enforce, default_meta(&c));
+        let r = finalize(
+            &c,
+            Verdict::allow(),
+            EnforcementMode::Enforce,
+            default_meta(&c),
+        );
         assert_eq!(r.input_identity, r.enforced_identity);
         assert!(r.input_identity.is_some());
         assert_eq!(r.identity_provider.as_deref(), Some(JCS_SHA256));
@@ -400,7 +424,13 @@ mod tests {
         validate_transform(&c, &t).unwrap();
         assert_eq!(c["target"]["url"], json!("evil"));
         assert_eq!(
-            validate_transform(&c, &Transform { path: "$target.missing.x".into(), value: json!(0) }),
+            validate_transform(
+                &c,
+                &Transform {
+                    path: "$target.missing.x".into(),
+                    value: json!(0)
+                }
+            ),
             Err(HostError::TransformInvalid)
         );
     }
@@ -482,7 +512,10 @@ mod tests {
         };
         let r = finalize(&c, Verdict::allow(), EnforcementMode::Enforce, meta);
         assert!(!r.proceeds());
-        assert_eq!(r.verdict.reason.as_deref(), Some("host_error:context_invalid"));
+        assert_eq!(
+            r.verdict.reason.as_deref(),
+            Some("host_error:context_invalid")
+        );
         assert!(r.enforced_identity.is_none());
         assert!(r.input_identity.is_some());
     }
@@ -500,7 +533,10 @@ mod tests {
         };
         let r = finalize(&c, Verdict::allow(), EnforcementMode::Enforce, meta);
         assert!(!r.proceeds());
-        assert_eq!(r.verdict.reason.as_deref(), Some("host_error:context_invalid"));
+        assert_eq!(
+            r.verdict.reason.as_deref(),
+            Some("host_error:context_invalid")
+        );
         assert!(r.input_identity.is_none() && r.enforced_identity.is_none());
         assert_eq!(r.session_id, "");
     }
@@ -510,12 +546,16 @@ mod tests {
         // §7.2/§10.3: records carry resolved knobs even when the host
         // left them unset.
         let c = ctx("pre_tool_call", json!({}));
-        let r = finalize(&c, Verdict::allow(), EnforcementMode::Enforce, default_meta(&c));
+        let r = finalize(
+            &c,
+            Verdict::allow(),
+            EnforcementMode::Enforce,
+            default_meta(&c),
+        );
         assert_eq!(
             r.composition.on_approval,
             Some(crate::composition::OnApproval::Stop)
         );
         assert!(r.composition.on_disagreement.is_none());
     }
-
 }

--- a/sdk/rust/core/src/ffi_surface.rs
+++ b/sdk/rust/core/src/ffi_surface.rs
@@ -18,9 +18,7 @@ use crate::composition::{
 };
 use crate::enforce::FinalizeMeta;
 use crate::types::{EnforcementMode, Verdict};
-use crate::{
-    canonical, enforce as enforce_mod, path, verdict, AgentContext, HostError, Transform,
-};
+use crate::{canonical, enforce as enforce_mod, path, verdict, AgentContext, HostError, Transform};
 use serde_json::Value;
 
 /// `(host_error_code, detail_message)`
@@ -88,7 +86,10 @@ pub fn apply_transform_ctx(
     let mut ctx: AgentContext = serde_json::from_str(ctx_json)
         .map_err(|e| err(HostError::ContextInvalid, format!("ctx: {e}")))?;
     let value = parse_json(value_json, "value")?;
-    let t = Transform { path: path_str.to_owned(), value };
+    let t = Transform {
+        path: path_str.to_owned(),
+        value,
+    };
     enforce_mod::apply_transform_to_ctx(&mut ctx, &t).map_err(|e| err(e, path_str))?;
     Ok(serde_json::to_string(&ctx).expect("ctx serialize"))
 }
@@ -103,7 +104,10 @@ pub fn validate_transform_ctx(
     let ctx: AgentContext = serde_json::from_str(ctx_json)
         .map_err(|e| err(HostError::ContextInvalid, format!("ctx: {e}")))?;
     let value = parse_json(value_json, "value")?;
-    let t = Transform { path: path_str.to_owned(), value };
+    let t = Transform {
+        path: path_str.to_owned(),
+        value,
+    };
     enforce_mod::validate_transform(&ctx, &t).map_err(|e| err(e, path_str))?;
     Ok("null".to_owned())
 }
@@ -127,10 +131,7 @@ pub fn validate_transform_ctx(
 ///                                 // winning transform, not yet applied
 /// }
 /// ```
-pub fn compose_aggregate(
-    composition_json: &str,
-    verdicts_json: &str,
-) -> Result<String, FfiError> {
+pub fn compose_aggregate(composition_json: &str, verdicts_json: &str) -> Result<String, FfiError> {
     let cfg: CompositionConfig = serde_json::from_str(composition_json)
         .map_err(|e| err(HostError::ContextInvalid, format!("composition: {e}")))?;
     let raw: Vec<Value> = serde_json::from_str(verdicts_json)
@@ -150,7 +151,9 @@ pub fn compose_aggregate(
         .map_err(|e| err(HostError::VerdictInvalid, format!("verdicts: {e}")))?;
     for (i, v) in all.iter().enumerate() {
         let synthesized_shape = v.decision == crate::Decision::Deny
-            && v.reason.as_deref().is_some_and(|r| r.starts_with("host_error:"))
+            && v.reason
+                .as_deref()
+                .is_some_and(|r| r.starts_with("host_error:"))
             && v.transform.is_none();
         if !synthesized_shape {
             v.validate()
@@ -247,17 +250,18 @@ pub fn finalize(
     let composition: CompositionConfig = serde_json::from_value(
         opts.get("composition").cloned().unwrap_or(Value::Null),
     )
-    .map_err(|e| err(HostError::ContextInvalid, format!("options.composition: {e}")))?;
+    .map_err(|e| {
+        err(
+            HostError::ContextInvalid,
+            format!("options.composition: {e}"),
+        )
+    })?;
     let verdicts = match opts.get("verdicts") {
         None | Some(Value::Null) => Vec::new(),
         Some(v) => serde_json::from_value(v.clone())
             .map_err(|e| err(HostError::ContextInvalid, format!("options.verdicts: {e}")))?,
     };
-    let opt_str = |k: &str| {
-        opts.get(k)
-            .and_then(Value::as_str)
-            .map(str::to_owned)
-    };
+    let opt_str = |k: &str| opts.get(k).and_then(Value::as_str).map(str::to_owned);
     // jcs-sha256 computes enforced_identity core-side from this ctx,
     // but the parse above already coerced any beyond-u64 literal — so
     // when the raw-text scan rejects, identity computation is
@@ -266,11 +270,16 @@ pub fn finalize(
     // the fail-closed record for exactly these contexts.
     let jcs_input_rejected = opt_str("identity_provider").as_deref() == Some("jcs-sha256")
         && canonical::scan_projection_raw(ctx_json).is_err();
+    let unchanged_since_input = opts
+        .get("unchanged_since_input")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
     let meta = FinalizeMeta {
         input_identity: opt_str("input_identity"),
         identity_provider: opt_str("identity_provider"),
         enforced_identity: opt_str("enforced_identity"),
         jcs_input_rejected,
+        unchanged_since_input,
         decided_by: opts
             .get("decided_by")
             .and_then(Value::as_u64)

--- a/sdk/rust/core/src/jcs.rs
+++ b/sdk/rust/core/src/jcs.rs
@@ -10,15 +10,15 @@
 //!
 
 use ryu_js::Buffer;
-use serde::Serialize;
 use serde::ser::Serializer;
-use serde_json::Error;
-use serde_json::Serializer as JsonSerializer;
-use serde_json::Value;
+use serde::Serialize;
 use serde_json::from_slice;
 use serde_json::from_str;
 use serde_json::ser::CharEscape;
 use serde_json::ser::Formatter;
+use serde_json::Error;
+use serde_json::Serializer as JsonSerializer;
+use serde_json::Value;
 use std::collections::BTreeMap;
 use std::io;
 use std::io::Write;
@@ -34,14 +34,14 @@ use std::mem::take;
 #[inline]
 pub fn to_string<T>(value: &T) -> Result<String, Error>
 where
-  T: Serialize + ?Sized,
+    T: Serialize + ?Sized,
 {
-  let data: Vec<u8> = to_vec(value)?;
+    let data: Vec<u8> = to_vec(value)?;
 
-  // SAFETY: We only emit valid UTF-8.
-  let data: String = unsafe { String::from_utf8_unchecked(data) };
+    // SAFETY: We only emit valid UTF-8.
+    let data: String = unsafe { String::from_utf8_unchecked(data) };
 
-  Ok(data)
+    Ok(data)
 }
 
 /// Serialize the given value as a JSON byte vector.
@@ -54,13 +54,13 @@ where
 #[inline]
 pub fn to_vec<T>(value: &T) -> Result<Vec<u8>, Error>
 where
-  T: Serialize + ?Sized,
+    T: Serialize + ?Sized,
 {
-  let mut data: Vec<u8> = Vec::with_capacity(128);
+    let mut data: Vec<u8> = Vec::with_capacity(128);
 
-  to_writer(&mut data, value)?;
+    to_writer(&mut data, value)?;
 
-  Ok(data)
+    Ok(data)
 }
 
 /// Serialize the given value as JSON into the IO stream.
@@ -73,10 +73,10 @@ where
 #[inline]
 pub fn to_writer<W, T>(writer: W, value: &T) -> Result<(), Error>
 where
-  W: Write,
-  T: Serialize + ?Sized,
+    W: Write,
+    T: Serialize + ?Sized,
 {
-  value.serialize(&mut JcsSerializer::new(writer))
+    value.serialize(&mut JcsSerializer::new(writer))
 }
 
 // -----------------------------------------------------------------------------
@@ -85,12 +85,12 @@ where
 
 #[inline]
 fn invalid_float() -> io::Error {
-  io::Error::other("invalid float value")
+    io::Error::other("invalid float value")
 }
 
 #[inline]
 fn invalid_key() -> io::Error {
-  io::Error::other("invalid UTF-8 key")
+    io::Error::other("invalid UTF-8 key")
 }
 
 // -----------------------------------------------------------------------------
@@ -98,43 +98,43 @@ fn invalid_key() -> io::Error {
 // -----------------------------------------------------------------------------
 
 struct Utf16Key {
-  tag: Vec<u16>,
-  key: Vec<u8>,
+    tag: Vec<u16>,
+    key: Vec<u8>,
 }
 
 impl Utf16Key {
-  fn new(key: Vec<u8>) -> io::Result<Self> {
-    let tag: Vec<u16> = from_slice::<Value>(&key)?
-      .as_str()
-      .ok_or_else(invalid_key)?
-      .encode_utf16()
-      .collect();
+    fn new(key: Vec<u8>) -> io::Result<Self> {
+        let tag: Vec<u16> = from_slice::<Value>(&key)?
+            .as_str()
+            .ok_or_else(invalid_key)?
+            .encode_utf16()
+            .collect();
 
-    Ok(Self { tag, key })
-  }
+        Ok(Self { tag, key })
+    }
 }
 
 impl PartialEq for Utf16Key {
-  #[inline]
-  fn eq(&self, other: &Self) -> bool {
-    self.tag.eq(&other.tag)
-  }
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.tag.eq(&other.tag)
+    }
 }
 
 impl Eq for Utf16Key {}
 
 impl PartialOrd for Utf16Key {
-  #[inline]
-  fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-    Some(self.cmp(other))
-  }
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl Ord for Utf16Key {
-  #[inline]
-  fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-    self.tag.cmp(&other.tag)
-  }
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.tag.cmp(&other.tag)
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -142,27 +142,27 @@ impl Ord for Utf16Key {
 // -----------------------------------------------------------------------------
 
 struct Entry {
-  object: BTreeMap<Utf16Key, Vec<u8>>,
-  next_key: Vec<u8>,
-  next_val: Vec<u8>,
-  complete: bool,
+    object: BTreeMap<Utf16Key, Vec<u8>>,
+    next_key: Vec<u8>,
+    next_val: Vec<u8>,
+    complete: bool,
 }
 
 impl Entry {
-  #[inline]
-  const fn new() -> Self {
-    Self {
-      object: BTreeMap::new(),
-      next_key: Vec::new(),
-      next_val: Vec::new(),
-      complete: false,
+    #[inline]
+    const fn new() -> Self {
+        Self {
+            object: BTreeMap::new(),
+            next_key: Vec::new(),
+            next_val: Vec::new(),
+            complete: false,
+        }
     }
-  }
 
-  #[inline]
-  const fn complete(&mut self, value: bool) {
-    self.complete = value;
-  }
+    #[inline]
+    const fn complete(&mut self, value: bool) {
+        self.complete = value;
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -170,356 +170,354 @@ impl Entry {
 // -----------------------------------------------------------------------------
 
 struct JcsFormatter {
-  entries: Vec<Entry>,
+    entries: Vec<Entry>,
 }
 
 impl JcsFormatter {
-  #[inline]
-  const fn new() -> Self {
-    Self {
-      entries: Vec::new(),
+    #[inline]
+    const fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
     }
-  }
 
-  #[inline]
-  fn scope<'a, W>(&'a mut self, writer: &'a mut W) -> Box<dyn Write + 'a>
-  where
-    W: Write + ?Sized,
-  {
-    match self.entry_mut() {
-      Some(entry) if entry.complete => Box::new(&mut entry.next_val),
-      Some(entry) => Box::new(&mut entry.next_key),
-      None => Box::new(writer),
+    #[inline]
+    fn scope<'a, W>(&'a mut self, writer: &'a mut W) -> Box<dyn Write + 'a>
+    where
+        W: Write + ?Sized,
+    {
+        match self.entry_mut() {
+            Some(entry) if entry.complete => Box::new(&mut entry.next_val),
+            Some(entry) => Box::new(&mut entry.next_key),
+            None => Box::new(writer),
+        }
     }
-  }
 
-  #[inline]
-  fn entry_mut(&mut self) -> Option<&mut Entry> {
-    self.entries.last_mut()
-  }
+    #[inline]
+    fn entry_mut(&mut self) -> Option<&mut Entry> {
+        self.entries.last_mut()
+    }
 }
 
 impl Formatter for JcsFormatter {
-  #[inline]
-  fn write_null<W>(&mut self, writer: &mut W) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.scope(writer).write_all(b"null")
-  }
-
-  #[inline]
-  fn write_bool<W>(&mut self, writer: &mut W, value: bool) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    if value {
-      self.scope(writer).write_all(b"true")
-    } else {
-      self.scope(writer).write_all(b"false")
-    }
-  }
-
-  #[inline]
-  fn write_char_escape<W>(&mut self, writer: &mut W, escape: CharEscape) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
     #[inline]
-    fn serialize(control: u8) -> [u8; 6] {
-      static HEX: [u8; 16] = *b"0123456789abcdef";
-      [
-        b'\\',
-        b'u',
-        b'0',
-        b'0',
-        HEX[(control >> 4) as usize],
-        HEX[(control & 0xF) as usize],
-      ]
+    fn write_null<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.scope(writer).write_all(b"null")
     }
 
-    match escape {
-      CharEscape::Quote => self.scope(writer).write_all(b"\\\""),
-      CharEscape::ReverseSolidus => self.scope(writer).write_all(b"\\\\"),
-      CharEscape::Solidus => self.scope(writer).write_all(b"/"),
-      CharEscape::Backspace => self.scope(writer).write_all(b"\\b"),
-      CharEscape::FormFeed => self.scope(writer).write_all(b"\\f"),
-      CharEscape::LineFeed => self.scope(writer).write_all(b"\\n"),
-      CharEscape::CarriageReturn => self.scope(writer).write_all(b"\\r"),
-      CharEscape::Tab => self.scope(writer).write_all(b"\\t"),
-      CharEscape::AsciiControl(control) => self.scope(writer).write_all(&serialize(control)),
-    }
-  }
-
-  #[inline]
-  fn write_number_str<W>(&mut self, writer: &mut W, value: &str) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.write_f64(writer, value.parse().map_err(io::Error::other)?)
-  }
-
-  #[inline]
-  fn write_string_fragment<W>(&mut self, writer: &mut W, fragment: &str) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.scope(writer).write_all(fragment.as_bytes())
-  }
-
-  #[inline]
-  fn write_raw_fragment<W>(&mut self, writer: &mut W, fragment: &str) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    let scope: Box<dyn Write> = self.scope(writer);
-    let value: Value = from_str(fragment)?;
-
-    to_writer(scope, &value).map_err(Into::into)
-  }
-
-  #[inline]
-  fn write_i8<W>(&mut self, writer: &mut W, value: i8) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.write_f64(writer, f64::from(value))
-  }
-
-  #[inline]
-  fn write_i16<W>(&mut self, writer: &mut W, value: i16) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.write_f64(writer, f64::from(value))
-  }
-
-  #[inline]
-  fn write_i32<W>(&mut self, writer: &mut W, value: i32) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.write_f64(writer, f64::from(value))
-  }
-
-  #[expect(clippy::cast_precision_loss)]
-  #[inline]
-  fn write_i64<W>(&mut self, writer: &mut W, value: i64) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.write_f64(writer, value as f64)
-  }
-
-  #[expect(clippy::cast_precision_loss)]
-  #[inline]
-  fn write_i128<W>(&mut self, writer: &mut W, value: i128) -> io::Result<()>
-  where
-    W: ?Sized + Write,
-  {
-    self.write_f64(writer, value as f64)
-  }
-
-  #[inline]
-  fn write_u8<W>(&mut self, writer: &mut W, value: u8) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.write_f64(writer, f64::from(value))
-  }
-
-  #[inline]
-  fn write_u16<W>(&mut self, writer: &mut W, value: u16) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.write_f64(writer, f64::from(value))
-  }
-
-  #[inline]
-  fn write_u32<W>(&mut self, writer: &mut W, value: u32) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.write_f64(writer, f64::from(value))
-  }
-
-  #[expect(clippy::cast_precision_loss)]
-  #[inline]
-  fn write_u64<W>(&mut self, writer: &mut W, value: u64) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.write_f64(writer, value as f64)
-  }
-
-  #[expect(clippy::cast_precision_loss)]
-  #[inline]
-  fn write_u128<W>(&mut self, writer: &mut W, value: u128) -> io::Result<()>
-  where
-    W: ?Sized + Write,
-  {
-    self.write_f64(writer, value as f64)
-  }
-
-  #[inline]
-  fn write_f32<W>(&mut self, writer: &mut W, value: f32) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.write_f64(writer, f64::from(value))
-  }
-
-  #[inline]
-  fn write_f64<W>(&mut self, writer: &mut W, value: f64) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    if value.is_finite() {
-      let mut buffer: Buffer = Buffer::new();
-      let mut writer: Box<dyn Write> = self.scope(writer);
-
-      writer.write_all(buffer.format_finite(value).as_bytes())
-    } else {
-      Err(invalid_float())
-    }
-  }
-
-  #[inline]
-  fn begin_string<W>(&mut self, writer: &mut W) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.scope(writer).write_all(b"\"")
-  }
-
-  #[inline]
-  fn end_string<W>(&mut self, writer: &mut W) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.scope(writer).write_all(b"\"")
-  }
-
-  #[inline]
-  fn begin_array<W>(&mut self, writer: &mut W) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.scope(writer).write_all(b"[")
-  }
-
-  #[inline]
-  fn end_array<W>(&mut self, writer: &mut W) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.scope(writer).write_all(b"]")
-  }
-
-  #[inline]
-  fn begin_array_value<W>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    if first {
-      Ok(())
-    } else {
-      self.scope(writer).write_all(b",")
-    }
-  }
-
-  #[inline]
-  fn end_array_value<W>(&mut self, _writer: &mut W) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    Ok(())
-  }
-
-  #[inline]
-  fn begin_object<W>(&mut self, _writer: &mut W) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self.entries.push(Entry::new());
-
-    Ok(())
-  }
-
-  fn end_object<W>(&mut self, writer: &mut W) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    let entry: Entry = self
-      .entries
-      .pop()
-      .ok_or_else(|| io::Error::other("end_object called before begin_object"))?;
-
-    let mut scope: Box<dyn Write> = self.scope(writer);
-
-    scope.write_all(b"{")?;
-
-    for (index, (key, val)) in entry.object.into_iter().enumerate() {
-      if index != 0 {
-        scope.write_all(b",")?;
-      }
-
-      scope.write_all(&key.key)?;
-      scope.write_all(b":")?;
-      scope.write_all(&val)?;
+    #[inline]
+    fn write_bool<W>(&mut self, writer: &mut W, value: bool) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        if value {
+            self.scope(writer).write_all(b"true")
+        } else {
+            self.scope(writer).write_all(b"false")
+        }
     }
 
-    scope.write_all(b"}")?;
+    #[inline]
+    fn write_char_escape<W>(&mut self, writer: &mut W, escape: CharEscape) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        #[inline]
+        fn serialize(control: u8) -> [u8; 6] {
+            static HEX: [u8; 16] = *b"0123456789abcdef";
+            [
+                b'\\',
+                b'u',
+                b'0',
+                b'0',
+                HEX[(control >> 4) as usize],
+                HEX[(control & 0xF) as usize],
+            ]
+        }
 
-    Ok(())
-  }
+        match escape {
+            CharEscape::Quote => self.scope(writer).write_all(b"\\\""),
+            CharEscape::ReverseSolidus => self.scope(writer).write_all(b"\\\\"),
+            CharEscape::Solidus => self.scope(writer).write_all(b"/"),
+            CharEscape::Backspace => self.scope(writer).write_all(b"\\b"),
+            CharEscape::FormFeed => self.scope(writer).write_all(b"\\f"),
+            CharEscape::LineFeed => self.scope(writer).write_all(b"\\n"),
+            CharEscape::CarriageReturn => self.scope(writer).write_all(b"\\r"),
+            CharEscape::Tab => self.scope(writer).write_all(b"\\t"),
+            CharEscape::AsciiControl(control) => self.scope(writer).write_all(&serialize(control)),
+        }
+    }
 
-  #[inline]
-  fn begin_object_key<W>(&mut self, _writer: &mut W, _first: bool) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self
-      .entry_mut()
-      .ok_or_else(|| io::Error::other("begin_object_key called before begin_object"))
-      .map(|entry| entry.complete(false))
-  }
+    #[inline]
+    fn write_number_str<W>(&mut self, writer: &mut W, value: &str) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.write_f64(writer, value.parse().map_err(io::Error::other)?)
+    }
 
-  #[inline]
-  fn end_object_key<W>(&mut self, _writer: &mut W) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    self
-      .entry_mut()
-      .ok_or_else(|| io::Error::other("end_object_key called before begin_object"))
-      .map(|entry| entry.complete(true))
-  }
+    #[inline]
+    fn write_string_fragment<W>(&mut self, writer: &mut W, fragment: &str) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.scope(writer).write_all(fragment.as_bytes())
+    }
 
-  #[inline]
-  fn begin_object_value<W>(&mut self, _writer: &mut W) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    Ok(())
-  }
+    #[inline]
+    fn write_raw_fragment<W>(&mut self, writer: &mut W, fragment: &str) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        let scope: Box<dyn Write> = self.scope(writer);
+        let value: Value = from_str(fragment)?;
 
-  fn end_object_value<W>(&mut self, _writer: &mut W) -> io::Result<()>
-  where
-    W: Write + ?Sized,
-  {
-    let entry: &mut Entry = self
-      .entry_mut()
-      .ok_or_else(|| io::Error::other("end_object_value called before begin_object"))?;
+        to_writer(scope, &value).map_err(Into::into)
+    }
 
-    let key: Vec<u8> = take(&mut entry.next_key);
-    let val: Vec<u8> = take(&mut entry.next_val);
+    #[inline]
+    fn write_i8<W>(&mut self, writer: &mut W, value: i8) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.write_f64(writer, f64::from(value))
+    }
 
-    entry.object.insert(Utf16Key::new(key)?, val);
+    #[inline]
+    fn write_i16<W>(&mut self, writer: &mut W, value: i16) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.write_f64(writer, f64::from(value))
+    }
 
-    Ok(())
-  }
+    #[inline]
+    fn write_i32<W>(&mut self, writer: &mut W, value: i32) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.write_f64(writer, f64::from(value))
+    }
+
+    #[expect(clippy::cast_precision_loss)]
+    #[inline]
+    fn write_i64<W>(&mut self, writer: &mut W, value: i64) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.write_f64(writer, value as f64)
+    }
+
+    #[expect(clippy::cast_precision_loss)]
+    #[inline]
+    fn write_i128<W>(&mut self, writer: &mut W, value: i128) -> io::Result<()>
+    where
+        W: ?Sized + Write,
+    {
+        self.write_f64(writer, value as f64)
+    }
+
+    #[inline]
+    fn write_u8<W>(&mut self, writer: &mut W, value: u8) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.write_f64(writer, f64::from(value))
+    }
+
+    #[inline]
+    fn write_u16<W>(&mut self, writer: &mut W, value: u16) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.write_f64(writer, f64::from(value))
+    }
+
+    #[inline]
+    fn write_u32<W>(&mut self, writer: &mut W, value: u32) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.write_f64(writer, f64::from(value))
+    }
+
+    #[expect(clippy::cast_precision_loss)]
+    #[inline]
+    fn write_u64<W>(&mut self, writer: &mut W, value: u64) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.write_f64(writer, value as f64)
+    }
+
+    #[expect(clippy::cast_precision_loss)]
+    #[inline]
+    fn write_u128<W>(&mut self, writer: &mut W, value: u128) -> io::Result<()>
+    where
+        W: ?Sized + Write,
+    {
+        self.write_f64(writer, value as f64)
+    }
+
+    #[inline]
+    fn write_f32<W>(&mut self, writer: &mut W, value: f32) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.write_f64(writer, f64::from(value))
+    }
+
+    #[inline]
+    fn write_f64<W>(&mut self, writer: &mut W, value: f64) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        if value.is_finite() {
+            let mut buffer: Buffer = Buffer::new();
+            let mut writer: Box<dyn Write> = self.scope(writer);
+
+            writer.write_all(buffer.format_finite(value).as_bytes())
+        } else {
+            Err(invalid_float())
+        }
+    }
+
+    #[inline]
+    fn begin_string<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.scope(writer).write_all(b"\"")
+    }
+
+    #[inline]
+    fn end_string<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.scope(writer).write_all(b"\"")
+    }
+
+    #[inline]
+    fn begin_array<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.scope(writer).write_all(b"[")
+    }
+
+    #[inline]
+    fn end_array<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.scope(writer).write_all(b"]")
+    }
+
+    #[inline]
+    fn begin_array_value<W>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        if first {
+            Ok(())
+        } else {
+            self.scope(writer).write_all(b",")
+        }
+    }
+
+    #[inline]
+    fn end_array_value<W>(&mut self, _writer: &mut W) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        Ok(())
+    }
+
+    #[inline]
+    fn begin_object<W>(&mut self, _writer: &mut W) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.entries.push(Entry::new());
+
+        Ok(())
+    }
+
+    fn end_object<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        let entry: Entry = self
+            .entries
+            .pop()
+            .ok_or_else(|| io::Error::other("end_object called before begin_object"))?;
+
+        let mut scope: Box<dyn Write> = self.scope(writer);
+
+        scope.write_all(b"{")?;
+
+        for (index, (key, val)) in entry.object.into_iter().enumerate() {
+            if index != 0 {
+                scope.write_all(b",")?;
+            }
+
+            scope.write_all(&key.key)?;
+            scope.write_all(b":")?;
+            scope.write_all(&val)?;
+        }
+
+        scope.write_all(b"}")?;
+
+        Ok(())
+    }
+
+    #[inline]
+    fn begin_object_key<W>(&mut self, _writer: &mut W, _first: bool) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.entry_mut()
+            .ok_or_else(|| io::Error::other("begin_object_key called before begin_object"))
+            .map(|entry| entry.complete(false))
+    }
+
+    #[inline]
+    fn end_object_key<W>(&mut self, _writer: &mut W) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        self.entry_mut()
+            .ok_or_else(|| io::Error::other("end_object_key called before begin_object"))
+            .map(|entry| entry.complete(true))
+    }
+
+    #[inline]
+    fn begin_object_value<W>(&mut self, _writer: &mut W) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        Ok(())
+    }
+
+    fn end_object_value<W>(&mut self, _writer: &mut W) -> io::Result<()>
+    where
+        W: Write + ?Sized,
+    {
+        let entry: &mut Entry = self
+            .entry_mut()
+            .ok_or_else(|| io::Error::other("end_object_value called before begin_object"))?;
+
+        let key: Vec<u8> = take(&mut entry.next_key);
+        let val: Vec<u8> = take(&mut entry.next_val);
+
+        entry.object.insert(Utf16Key::new(key)?, val);
+
+        Ok(())
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -529,233 +527,229 @@ impl Formatter for JcsFormatter {
 type Proxy<'a, W> = &'a mut JsonSerializer<W, JcsFormatter>;
 
 struct JcsSerializer<W> {
-  inner: JsonSerializer<W, JcsFormatter>,
+    inner: JsonSerializer<W, JcsFormatter>,
 }
 
 impl<W> JcsSerializer<W> {
-  #[inline]
-  fn new(writer: W) -> Self
-  where
-    W: Write,
-  {
-    Self {
-      inner: JsonSerializer::with_formatter(writer, JcsFormatter::new()),
+    #[inline]
+    fn new(writer: W) -> Self
+    where
+        W: Write,
+    {
+        Self {
+            inner: JsonSerializer::with_formatter(writer, JcsFormatter::new()),
+        }
     }
-  }
 }
 
 impl<'a, W> Serializer for &'a mut JcsSerializer<W>
 where
-  W: Write,
+    W: Write,
 {
-  type Ok = <Proxy<'a, W> as Serializer>::Ok;
-  type Error = <Proxy<'a, W> as Serializer>::Error;
+    type Ok = <Proxy<'a, W> as Serializer>::Ok;
+    type Error = <Proxy<'a, W> as Serializer>::Error;
 
-  type SerializeSeq = <Proxy<'a, W> as Serializer>::SerializeSeq;
-  type SerializeTuple = <Proxy<'a, W> as Serializer>::SerializeTuple;
-  type SerializeTupleStruct = <Proxy<'a, W> as Serializer>::SerializeTupleStruct;
-  type SerializeTupleVariant = <Proxy<'a, W> as Serializer>::SerializeTupleVariant;
-  type SerializeMap = <Proxy<'a, W> as Serializer>::SerializeMap;
-  type SerializeStruct = <Proxy<'a, W> as Serializer>::SerializeStruct;
-  type SerializeStructVariant = <Proxy<'a, W> as Serializer>::SerializeStructVariant;
+    type SerializeSeq = <Proxy<'a, W> as Serializer>::SerializeSeq;
+    type SerializeTuple = <Proxy<'a, W> as Serializer>::SerializeTuple;
+    type SerializeTupleStruct = <Proxy<'a, W> as Serializer>::SerializeTupleStruct;
+    type SerializeTupleVariant = <Proxy<'a, W> as Serializer>::SerializeTupleVariant;
+    type SerializeMap = <Proxy<'a, W> as Serializer>::SerializeMap;
+    type SerializeStruct = <Proxy<'a, W> as Serializer>::SerializeStruct;
+    type SerializeStructVariant = <Proxy<'a, W> as Serializer>::SerializeStructVariant;
 
-  #[inline]
-  fn serialize_bool(self, value: bool) -> Result<Self::Ok, Self::Error> {
-    self.inner.serialize_bool(value)
-  }
-
-  #[inline]
-  fn serialize_i8(self, value: i8) -> Result<Self::Ok, Self::Error> {
-    self.inner.serialize_i8(value)
-  }
-
-  #[inline]
-  fn serialize_i16(self, value: i16) -> Result<Self::Ok, Self::Error> {
-    self.inner.serialize_i16(value)
-  }
-
-  #[inline]
-  fn serialize_i32(self, value: i32) -> Result<Self::Ok, Self::Error> {
-    self.inner.serialize_i32(value)
-  }
-
-  #[inline]
-  fn serialize_i64(self, value: i64) -> Result<Self::Ok, Self::Error> {
-    self.inner.serialize_i64(value)
-  }
-
-  #[inline]
-  fn serialize_u8(self, value: u8) -> Result<Self::Ok, Self::Error> {
-    self.inner.serialize_u8(value)
-  }
-
-  #[inline]
-  fn serialize_u16(self, value: u16) -> Result<Self::Ok, Self::Error> {
-    self.inner.serialize_u16(value)
-  }
-
-  #[inline]
-  fn serialize_u32(self, value: u32) -> Result<Self::Ok, Self::Error> {
-    self.inner.serialize_u32(value)
-  }
-
-  #[inline]
-  fn serialize_u64(self, value: u64) -> Result<Self::Ok, Self::Error> {
-    self.inner.serialize_u64(value)
-  }
-
-  #[inline]
-  fn serialize_f32(self, value: f32) -> Result<Self::Ok, Self::Error> {
-    if value.is_finite() {
-      self.inner.serialize_f32(value)
-    } else {
-      Err(Self::Error::io(invalid_float()))
+    #[inline]
+    fn serialize_bool(self, value: bool) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_bool(value)
     }
-  }
 
-  #[inline]
-  fn serialize_f64(self, value: f64) -> Result<Self::Ok, Self::Error> {
-    if value.is_finite() {
-      self.inner.serialize_f64(value)
-    } else {
-      Err(Self::Error::io(invalid_float()))
+    #[inline]
+    fn serialize_i8(self, value: i8) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_i8(value)
     }
-  }
 
-  #[inline]
-  fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {
-    self.inner.serialize_char(value)
-  }
+    #[inline]
+    fn serialize_i16(self, value: i16) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_i16(value)
+    }
 
-  #[inline]
-  fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
-    self.inner.serialize_str(value)
-  }
+    #[inline]
+    fn serialize_i32(self, value: i32) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_i32(value)
+    }
 
-  #[inline]
-  fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
-    self.inner.serialize_bytes(value)
-  }
+    #[inline]
+    fn serialize_i64(self, value: i64) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_i64(value)
+    }
 
-  #[inline]
-  fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-    self.inner.serialize_none()
-  }
+    #[inline]
+    fn serialize_u8(self, value: u8) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_u8(value)
+    }
 
-  #[inline]
-  fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
-  where
-    T: ?Sized + Serialize,
-  {
-    self.inner.serialize_some(value)
-  }
+    #[inline]
+    fn serialize_u16(self, value: u16) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_u16(value)
+    }
 
-  #[inline]
-  fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-    self.inner.serialize_unit()
-  }
+    #[inline]
+    fn serialize_u32(self, value: u32) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_u32(value)
+    }
 
-  #[inline]
-  fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
-    self.inner.serialize_unit_struct(name)
-  }
+    #[inline]
+    fn serialize_u64(self, value: u64) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_u64(value)
+    }
 
-  #[inline]
-  fn serialize_unit_variant(
-    self,
-    name: &'static str,
-    variant_index: u32,
-    variant: &'static str,
-  ) -> Result<Self::Ok, Self::Error> {
-    self
-      .inner
-      .serialize_unit_variant(name, variant_index, variant)
-  }
+    #[inline]
+    fn serialize_f32(self, value: f32) -> Result<Self::Ok, Self::Error> {
+        if value.is_finite() {
+            self.inner.serialize_f32(value)
+        } else {
+            Err(Self::Error::io(invalid_float()))
+        }
+    }
 
-  #[inline]
-  fn serialize_newtype_struct<T>(
-    self,
-    name: &'static str,
-    value: &T,
-  ) -> Result<Self::Ok, Self::Error>
-  where
-    T: ?Sized + Serialize,
-  {
-    self.inner.serialize_newtype_struct(name, value)
-  }
+    #[inline]
+    fn serialize_f64(self, value: f64) -> Result<Self::Ok, Self::Error> {
+        if value.is_finite() {
+            self.inner.serialize_f64(value)
+        } else {
+            Err(Self::Error::io(invalid_float()))
+        }
+    }
 
-  #[inline]
-  fn serialize_newtype_variant<T>(
-    self,
-    name: &'static str,
-    variant_index: u32,
-    variant: &'static str,
-    value: &T,
-  ) -> Result<Self::Ok, Self::Error>
-  where
-    T: ?Sized + Serialize,
-  {
-    self
-      .inner
-      .serialize_newtype_variant(name, variant_index, variant, value)
-  }
+    #[inline]
+    fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_char(value)
+    }
 
-  #[inline]
-  fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-    self.inner.serialize_seq(len)
-  }
+    #[inline]
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_str(value)
+    }
 
-  #[inline]
-  fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-    self.inner.serialize_tuple(len)
-  }
+    #[inline]
+    fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_bytes(value)
+    }
 
-  #[inline]
-  fn serialize_tuple_struct(
-    self,
-    name: &'static str,
-    len: usize,
-  ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-    self.inner.serialize_tuple_struct(name, len)
-  }
+    #[inline]
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_none()
+    }
 
-  #[inline]
-  fn serialize_tuple_variant(
-    self,
-    name: &'static str,
-    variant_index: u32,
-    variant: &'static str,
-    len: usize,
-  ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-    self
-      .inner
-      .serialize_tuple_variant(name, variant_index, variant, len)
-  }
+    #[inline]
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.inner.serialize_some(value)
+    }
 
-  #[inline]
-  fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-    self.inner.serialize_map(len)
-  }
+    #[inline]
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_unit()
+    }
 
-  #[inline]
-  fn serialize_struct(
-    self,
-    name: &'static str,
-    len: usize,
-  ) -> Result<Self::SerializeStruct, Self::Error> {
-    self.inner.serialize_struct(name, len)
-  }
+    #[inline]
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_unit_struct(name)
+    }
 
-  #[inline]
-  fn serialize_struct_variant(
-    self,
-    name: &'static str,
-    variant_index: u32,
-    variant: &'static str,
-    len: usize,
-  ) -> Result<Self::SerializeStructVariant, Self::Error> {
-    self
-      .inner
-      .serialize_struct_variant(name, variant_index, variant, len)
-  }
+    #[inline]
+    fn serialize_unit_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.inner
+            .serialize_unit_variant(name, variant_index, variant)
+    }
+
+    #[inline]
+    fn serialize_newtype_struct<T>(
+        self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.inner.serialize_newtype_struct(name, value)
+    }
+
+    #[inline]
+    fn serialize_newtype_variant<T>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.inner
+            .serialize_newtype_variant(name, variant_index, variant, value)
+    }
+
+    #[inline]
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        self.inner.serialize_seq(len)
+    }
+
+    #[inline]
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.inner.serialize_tuple(len)
+    }
+
+    #[inline]
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.inner.serialize_tuple_struct(name, len)
+    }
+
+    #[inline]
+    fn serialize_tuple_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        self.inner
+            .serialize_tuple_variant(name, variant_index, variant, len)
+    }
+
+    #[inline]
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        self.inner.serialize_map(len)
+    }
+
+    #[inline]
+    fn serialize_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        self.inner.serialize_struct(name, len)
+    }
+
+    #[inline]
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        self.inner
+            .serialize_struct_variant(name, variant_index, variant, len)
+    }
 }

--- a/sdk/rust/core/src/lib.rs
+++ b/sdk/rust/core/src/lib.rs
@@ -33,10 +33,10 @@
 
 mod builder;
 mod canonical;
-mod jcs;
 pub mod composition;
 mod emitter;
 mod enforce;
+mod jcs;
 mod path;
 mod types;
 mod verdict;
@@ -57,8 +57,8 @@ pub use emitter::{IdentityProvider, InterceptionBlocked, InterceptionEmitter};
 pub use enforce::{apply_transform_to_ctx, finalize, validate_transform, FinalizeMeta};
 pub use path::{apply as apply_transform_path, parse as parse_transform_path, resolve, Segment};
 pub use types::{
-    AgentContext, ApprovalOutcome, ApprovalRequest, ApprovalResolution, ApprovalResolver,
-    Decision, EnforcementMode, Evidence, HostError, Interceptor, InterceptionPoint,
-    InterceptionRecord, Transform, Verdict, VerdictSummary, Warning, JCS_SHA256, SPEC_VERSION,
+    AgentContext, ApprovalOutcome, ApprovalRequest, ApprovalResolution, ApprovalResolver, Decision,
+    EnforcementMode, Evidence, HostError, InterceptionPoint, InterceptionRecord, Interceptor,
+    Transform, Verdict, VerdictSummary, Warning, JCS_SHA256, SPEC_VERSION,
 };
 pub use verdict::from_wire as verdict_from_wire;

--- a/sdk/rust/core/src/path.rs
+++ b/sdk/rust/core/src/path.rs
@@ -135,12 +135,8 @@ pub fn apply(mut target: Value, path: &str, value: Value) -> Result<Value, HostE
 
 fn step_mut<'a>(cur: &'a mut Value, seg: &Segment) -> Result<&'a mut Value, HostError> {
     match (cur, seg) {
-        (Value::Object(m), Segment::Member(k)) => {
-            m.get_mut(k).ok_or(HostError::TransformInvalid)
-        }
-        (Value::Array(a), Segment::Index(i)) => {
-            a.get_mut(*i).ok_or(HostError::TransformInvalid)
-        }
+        (Value::Object(m), Segment::Member(k)) => m.get_mut(k).ok_or(HostError::TransformInvalid),
+        (Value::Array(a), Segment::Index(i)) => a.get_mut(*i).ok_or(HostError::TransformInvalid),
         _ => Err(HostError::TransformInvalid),
     }
 }

--- a/sdk/rust/core/src/types.rs
+++ b/sdk/rust/core/src/types.rs
@@ -486,5 +486,4 @@ mod verdict_validate_tests {
         assert!(validate_provider_name("1abc").is_err());
         assert!(validate_provider_name("").is_err());
     }
-
 }

--- a/sdk/rust/core/src/verdict.rs
+++ b/sdk/rust/core/src/verdict.rs
@@ -9,9 +9,10 @@ use serde_json::Value;
 /// per §5. Any violation yields `HostError::VerdictInvalid` with a detail
 /// message; the caller synthesizes the `deny` verdict.
 pub fn from_wire(raw: &Value) -> Result<Verdict, (HostError, String)> {
-    let obj = raw
-        .as_object()
-        .ok_or((HostError::VerdictInvalid, "verdict must be a JSON object".into()))?;
+    let obj = raw.as_object().ok_or((
+        HostError::VerdictInvalid,
+        "verdict must be a JSON object".into(),
+    ))?;
 
     let decision = match obj.get("decision").and_then(Value::as_str) {
         Some("allow") => Decision::Allow,
@@ -46,9 +47,7 @@ pub fn from_wire(raw: &Value) -> Result<Verdict, (HostError, String)> {
                 Value::Object(m) => {
                     let reason = match m.get("reason") {
                         None | Some(Value::Null) => None,
-                        Some(Value::String(s)) if !s.starts_with("host_error:") => {
-                            Some(s.clone())
-                        }
+                        Some(Value::String(s)) if !s.starts_with("host_error:") => Some(s.clone()),
                         _ => {
                             return Err((
                                 HostError::VerdictInvalid,
@@ -221,7 +220,6 @@ fn opt_string(
         )),
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/sdk/rust/core/tests/ctk_reference.rs
+++ b/sdk/rust/core/tests/ctk_reference.rs
@@ -9,7 +9,11 @@ use agent_hooks::ctk::{load_vectors, run_vector, ReferenceHarness};
 async fn ctk_reference_all_vectors() {
     let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../../../conformance/vectors");
     let vectors = load_vectors(dir).expect("load vectors");
-    assert!(vectors.len() >= 30, "expected >=30 vectors, got {}", vectors.len());
+    assert!(
+        vectors.len() >= 30,
+        "expected >=30 vectors, got {}",
+        vectors.len()
+    );
     let mut unexpected: Vec<String> = Vec::new();
     let mut skipped: Vec<String> = Vec::new();
     for vector in &vectors {

--- a/sdk/rust/core/tests/golden_identity.rs
+++ b/sdk/rust/core/tests/golden_identity.rs
@@ -40,8 +40,7 @@ fn golden_context_identity() {
         if f["expect"].get("error").is_some() {
             // §10.2: out-of-domain contexts fail closed — never a
             // real-looking identity.
-            let (e, _) = context_identity(&ctx)
-                .expect_err("negative fixture must be rejected");
+            let (e, _) = context_identity(&ctx).expect_err("negative fixture must be rejected");
             assert_eq!(e.to_string(), "host_error:context_invalid", "{}", f["id"]);
             continue;
         }
@@ -64,14 +63,23 @@ fn golden_provider_rejects_beyond_2_53() {
     let ctx: AgentContext = serde_json::from_value(f["ctx"].clone()).unwrap();
     let (e, detail) = context_identity(&ctx).unwrap_err();
     assert_eq!(e.to_string(), "host_error:context_invalid");
-    assert!(detail.contains("string-encode 64-bit identifiers"), "{detail}");
+    assert!(
+        detail.contains("string-encode 64-bit identifiers"),
+        "{detail}"
+    );
 }
 
 #[test]
 fn golden_l2_l3_stripped() {
     let fs = load();
-    let g05 = fs.iter().find(|f| f["id"] == "G-05-l2-l3-stripped").unwrap();
-    let g05b = fs.iter().find(|f| f["id"] == "G-05b-l2-l3-baseline").unwrap();
+    let g05 = fs
+        .iter()
+        .find(|f| f["id"] == "G-05-l2-l3-stripped")
+        .unwrap();
+    let g05b = fs
+        .iter()
+        .find(|f| f["id"] == "G-05b-l2-l3-baseline")
+        .unwrap();
     assert_eq!(
         g05["expect"]["context_identity"], g05b["expect"]["context_identity"],
         "L2/L3 fields must not affect context_identity (§10.2)"

--- a/sdk/rust/core/tests/property.rs
+++ b/sdk/rust/core/tests/property.rs
@@ -16,16 +16,15 @@ fn arb_json() -> impl Strategy<Value = serde_json::Value> {
         Just(serde_json::Value::Null),
         any::<bool>().prop_map(serde_json::Value::from),
         // In-domain numbers only here; out-of-domain is its own test.
-        (-9_007_199_254_740_991_i64..=9_007_199_254_740_991_i64)
-            .prop_map(serde_json::Value::from),
-        any::<f64>().prop_filter("finite", |f| f.is_finite())
+        (-9_007_199_254_740_991_i64..=9_007_199_254_740_991_i64).prop_map(serde_json::Value::from),
+        any::<f64>()
+            .prop_filter("finite", |f| f.is_finite())
             .prop_map(serde_json::Value::from),
         "\\PC{0,12}".prop_map(serde_json::Value::from),
     ];
     leaf.prop_recursive(4, 32, 6, |inner| {
         prop_oneof![
-            prop::collection::vec(inner.clone(), 0..6)
-                .prop_map(serde_json::Value::from),
+            prop::collection::vec(inner.clone(), 0..6).prop_map(serde_json::Value::from),
             prop::collection::btree_map("\\PC{0,8}", inner, 0..6)
                 .prop_map(|m| serde_json::Value::Object(m.into_iter().collect())),
         ]

--- a/sdk/rust/ffi/src/lib.rs
+++ b/sdk/rust/ffi/src/lib.rs
@@ -335,7 +335,9 @@ mod tests {
         let code = if (*r).error_code.is_null() {
             String::new()
         } else {
-            CStr::from_ptr((*r).error_code).to_string_lossy().into_owned()
+            CStr::from_ptr((*r).error_code)
+                .to_string_lossy()
+                .into_owned()
         };
         ah_free_result(r);
         (ok, value, code)
@@ -377,7 +379,10 @@ mod tests {
             let (ok, detail, code) = call1(ah_context_identity, ctx);
             assert_eq!(ok, 0);
             assert_eq!(code, "host_error:context_invalid");
-            assert!(detail.contains("string-encode 64-bit identifiers"), "{detail}");
+            assert!(
+                detail.contains("string-encode 64-bit identifiers"),
+                "{detail}"
+            );
         }
     }
 

--- a/sdk/typescript/src/emitter.ts
+++ b/sdk/typescript/src/emitter.ts
@@ -213,7 +213,16 @@ export class InterceptionEmitter {
     return this;
   }
 
-  /** Declare the composition profile for subsequent emissions (§7.1). */
+  /**
+   * Declare the composition profile for subsequent emissions (§7.1).
+   *
+   * The default (`sequential/first_deny`, `on_approval: stop`) is the
+   * configuration §14 warns about: after an approval lifts a liftable
+   * deny, interceptors registered after the escalating one never run
+   * for that emission (`fold_truncated` on the record). Register
+   * must-run controls first, or use `sequential/run_all` / a parallel
+   * profile. See docs/PRODUCTION.md.
+   */
   setComposition(composition: CompositionConfig): this {
     this.composition = composition;
     return this;


### PR DESCRIPTION
Performance, cross-platform, and formatting follow-ups from the 2026-07-09 architectural review.

- **Formatting:** one-time normalization (cargo fmt, ruff format, dotnet format), then gates in the existing CI jobs: `cargo fmt --check`, `ruff format --check`, `dotnet format --verify-no-changes`, `gofmt -l`, and a generated-binding drift gate for `binding.js`/`binding.d.ts` after the napi build. Root `.editorconfig`.
- **Cross-platform:** `rust-xplat` and `dotnet-xplat` matrix jobs (macos/windows) — core tests plus the FFI loading path per OS. Advisory: required check names stay stable and always-reporting.
- **Performance:** criterion benches (identity/aggregate/full-emit at 1KiB–1MiB × 1–10 interceptors), latency budget in ARCHITECTURE.md, and two allow-path eliminations: the Rust emitter's per-interceptor defensive deep copy (the `&AgentContext` borrow is the isolation), and a second full canonicalize+hash in `finalize` when no transform folded (`unchanged_since_input`, additive FFI option defaulting to the old behavior). Bench gating in CI deliberately omitted (runner variance); documented to run before release tags.
- **Remainder:** change-class workflow (spec:breaking label ⇄ version bump coupling; labels created), the §14 `first_deny`+`stop` pitfall surfaced in all five emitters' `set_composition` docs, `.claude/` gitignored.

Local matrix: Rust 6 suites + clippy + fmt clean, Python 175 + ruff format clean, TypeScript 122 + zero binding drift, .NET 116 + format clean, generators drift-clean. Go via CI (gofmt gate new — first run verifies).
