### PR TITLE
ci: permit main-ref dry-runs; publish only from tag refs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,12 +71,12 @@ jobs:
           path: sdk/python
           artifact-name: sbom-python.spdx.json
       - name: Attest build provenance
-        if: env.DRY_RUN != 'true'
+        if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v2
         with:
           subject-path: dist/*
       - name: Publish to PyPI (trusted publishing)
-        if: env.DRY_RUN != 'true'
+        if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1
         with:
           packages-dir: dist
@@ -102,16 +102,16 @@ jobs:
           path: sdk/rust
           artifact-name: sbom-rust.spdx.json
       - name: Attest build provenance
-        if: env.DRY_RUN != 'true'
+        if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v2
         with:
           subject-path: sdk/rust/target/package/*.crate
       - name: Authenticate to crates.io (trusted publishing)
-        if: env.DRY_RUN != 'true'
+        if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
         id: cratesio-auth
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1
       - name: Publish to crates.io
-        if: env.DRY_RUN != 'true'
+        if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
         run: cargo publish --locked -p agent-hooks-sdk
         working-directory: sdk/rust
         env:
@@ -137,12 +137,12 @@ jobs:
           path: sdk/typescript
           artifact-name: sbom-typescript.spdx.json
       - name: Attest build provenance
-        if: env.DRY_RUN != 'true'
+        if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v2
         with:
           subject-path: sdk/typescript/*.tgz
       - name: Publish to npm (trusted publishing)
-        if: env.DRY_RUN != 'true'
+        if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
         # OIDC trusted publishing: no token. Requires npm >= 11.5.1 and a
         # trusted publisher configured on the package (repo
         # responsibleai/agent-hooks, workflow release.yml, environment
@@ -180,18 +180,18 @@ jobs:
           path: sdk/dotnet
           artifact-name: sbom-dotnet.spdx.json
       - name: Attest build provenance
-        if: env.DRY_RUN != 'true'
+        if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v2
         with:
           subject-path: sdk/dotnet/dist/*.nupkg
       - name: Authenticate to NuGet (trusted publishing)
-        if: env.DRY_RUN != 'true'
+        if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
         id: nuget-login
         uses: NuGet/login@d2e63aec27eb60a1d40f4c1c9440059cbf27d19a # v1
         with:
           user: ${{ secrets.NUGET_USER }}
       - name: Publish to NuGet
-        if: env.DRY_RUN != 'true'
+        if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
         run: dotnet nuget push dist/*.nupkg --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json
         working-directory: sdk/dotnet
 


### PR DESCRIPTION
Dry-run dispatches from `main` were rejected at the `release` environment gate (its deployment policy allowed only `v*` tags) — all four environment-bound jobs failed with zero steps executed. `main` is now an allowed deployment ref for the environment, and every publish/attest/auth step gains `github.ref_type == 'tag'` alongside the dry-run flag, so a dispatch from `main` can never publish regardless of inputs.