### PR TITLE
ci: idempotent registry publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,8 @@ jobs:
         if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1
         with:
+          skip-existing: true
+        with:
           packages-dir: dist
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with: { name: python-dist, path: dist/* }
@@ -112,7 +114,14 @@ jobs:
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1
       - name: Publish to crates.io
         if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
-        run: cargo publish --locked -p agent-hooks-sdk
+        # Idempotent: skip when this version already exists (sparse index).
+        run: |
+          V=$(cargo pkgid -p agent-hooks-sdk | sed 's/.*#//')
+          if curl -sf https://index.crates.io/ag/en/agent-hooks-sdk | grep -q "\"vers\":\"$V\""; then
+            echo "agent-hooks-sdk $V already on crates.io — skipping"
+          else
+            cargo publish --locked -p agent-hooks-sdk
+          fi
         working-directory: sdk/rust
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cratesio-auth.outputs.token }}
@@ -155,7 +164,11 @@ jobs:
           npm install -g npm@latest
           V=$(node -p "require('./package.json').version")
           case "$V" in *-*) T=alpha;; *) T=latest;; esac
-          npm publish --access public --tag "$T"
+          if npm view "@responsibleai/agent-hooks@$V" version >/dev/null 2>&1; then
+            echo "@responsibleai/agent-hooks@$V already on npm — skipping"
+          else
+            npm publish --access public --tag "$T"
+          fi
         working-directory: sdk/typescript
 
   dotnet:
@@ -192,7 +205,7 @@ jobs:
           user: ${{ secrets.NUGET_USER }}
       - name: Publish to NuGet
         if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
-        run: dotnet nuget push dist/*.nupkg --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push dist/*.nupkg --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
         working-directory: sdk/dotnet
 
   # Go has no upload: the module proxy serves the tag. This job proves


### PR DESCRIPTION
A release re-run (after a partial run or a moved tag) must skip registries where the version already exists instead of failing: `skip-existing` for the PyPI action, a sparse-index existence guard for crates.io, an `npm view` guard for npm, and `--skip-duplicate` for NuGet push.