### PR TITLE
ci: merge duplicated with-block in the PyPI publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,9 +79,8 @@ jobs:
         if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1
         with:
-          skip-existing: true
-        with:
           packages-dir: dist
+          skip-existing: true
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with: { name: python-dist, path: dist/* }
 


### PR DESCRIPTION
PR #24 added a second `with:` key to the PyPI publish step, which already had one. PyYAML tolerates duplicate keys (last wins) but the Actions parser rejects the entire workflow file — every event since the merge failed instantly with 'workflow file issue', including the retagged release. Blocks merged; `actionlint` now clean (and worth adding to CI — PR5's formatter gates did not cover workflow files).