### PR TITLE
ci: strip the crate name from the pkgid version in the crates guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
         if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
         # Idempotent: skip when this version already exists (sparse index).
         run: |
-          V=$(cargo pkgid -p agent-hooks-sdk | sed 's/.*#//')
+          V=$(cargo pkgid -p agent-hooks-sdk | sed 's/.*[#@]//')
           if curl -sf https://index.crates.io/ag/en/agent-hooks-sdk | grep -q "\"vers\":\"$V\""; then
             echo "agent-hooks-sdk $V already on crates.io — skipping"
           else


### PR DESCRIPTION
`cargo pkgid` yields `...#name@version` when the package name differs from its directory; the idempotency guard compared `name@version` against the index `vers` field, never matched, and fell through to a duplicate-publish error (release run 29455425659, rust leg). One-character fix: strip through `[#@]`. No retag needed — all five registries carry alpha.2.