### PR TITLE
Record timestamp/trace correlation, gate/parser unification, typed finalize options

### DIFF
--- a/conformance/vectors.schema.json
+++ b/conformance/vectors.schema.json
@@ -455,6 +455,13 @@
                   "type": "string"
                 },
                 "description": "Dotted paths that MUST NOT resolve on the matched record (e.g. verdict.transform.value under the §10.3 payload-free projection)."
+              },
+              "present": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Dotted paths that MUST resolve on the matched record without pinning the value (e.g. timestamp, whose value is host-dynamic)."
               }
             }
           },

--- a/conformance/vectors/AH-CTK-081-run-all-aggregate.json
+++ b/conformance/vectors/AH-CTK-081-run-all-aggregate.json
@@ -108,7 +108,13 @@
           "verdicts[0].decision": "transform",
           "verdicts[1].decision": "deny",
           "verdicts[2].decision": "allow"
-        }
+        },
+        "present": [
+          "timestamp"
+        ],
+        "absent": [
+          "trace"
+        ]
       }
     ],
     "run_outcome": "completed"

--- a/sdk/dotnet/src/AgentHooks/InterceptionEmitter.cs
+++ b/sdk/dotnet/src/AgentHooks/InterceptionEmitter.cs
@@ -783,6 +783,8 @@ public sealed class InterceptionEmitter
                 ?? (IReadOnlyList<VerdictSummary>)[],
             (bool?)r["fold_truncated"],
             (string?)r["resolved_by"],
-            (int?)r["interceptors_registered"] ?? 0);
+            (int?)r["interceptors_registered"] ?? 0,
+            (string?)r["timestamp"],
+            r["trace"] is JsonObject t ? TraceContext.FromWire(t) : null);
     }
 }

--- a/sdk/dotnet/src/AgentHooks/Types.cs
+++ b/sdk/dotnet/src/AgentHooks/Types.cs
@@ -419,6 +419,23 @@ public sealed record VerdictSummary(
         (string?)o["name"]);
 }
 
+/// <summary>W3C Trace Context correlation echoed onto the record from
+/// the context's optional <c>trace</c> block (§4.5, §10.3).
+/// Payload-free: identifiers only.</summary>
+public sealed record TraceContext(string? TraceId, string? SpanId)
+{
+    public JsonObject ToWire()
+    {
+        var o = new JsonObject();
+        if (TraceId is not null) o["trace_id"] = TraceId;
+        if (SpanId is not null) o["span_id"] = SpanId;
+        return o;
+    }
+
+    public static TraceContext FromWire(JsonObject o) =>
+        new((string?)o["trace_id"], (string?)o["span_id"]);
+}
+
 /// <summary>Host-side record of one emission (§10.3).
 ///
 /// Payload-free by design: the identities (when a provider is declared)
@@ -441,7 +458,9 @@ public sealed record InterceptionRecord(
     IReadOnlyList<VerdictSummary> Verdicts,
     bool? FoldTruncated,
     string? ResolvedBy,
-    int InterceptorsRegistered = 0)
+    int InterceptorsRegistered = 0,
+    string? Timestamp = null,
+    TraceContext? Trace = null)
 {
     /// <summary>Whether the guarded action executes (§6, §8).</summary>
     public bool Proceeds => Mode == EnforcementMode.EvaluateOnly || Verdict.Decision.Permits();
@@ -466,6 +485,8 @@ public sealed record InterceptionRecord(
         };
         if (Verdicts.Count > 0)
             o["verdicts"] = new JsonArray(Verdicts.Select(v => (JsonNode)v.ToWire()).ToArray());
+        if (Timestamp is not null) o["timestamp"] = Timestamp;
+        if (Trace is not null) o["trace"] = Trace.ToWire();
         if (FoldTruncated is not null) o["fold_truncated"] = FoldTruncated;
         if (ResolvedBy is not null) o["resolved_by"] = ResolvedBy;
         o["interceptors_registered"] = InterceptorsRegistered;

--- a/sdk/go/agenthooks/types.go
+++ b/sdk/go/agenthooks/types.go
@@ -337,6 +337,13 @@ type VerdictSummary struct {
 // duplicating the (possibly sensitive) payload into audit storage.
 // Composition makes the record interpretable without out-of-band
 // knowledge of host configuration.
+// TraceContext carries the W3C Trace Context identifiers echoed onto
+// the record (§10.3). Payload-free: identifiers only.
+type TraceContext struct {
+	TraceID *string `json:"trace_id,omitempty"`
+	SpanID  *string `json:"span_id,omitempty"`
+}
+
 type InterceptionRecord struct {
 	InterceptionPoint InterceptionPoint `json:"interception_point"`
 	Mode              EnforcementMode   `json:"mode"`
@@ -354,6 +361,13 @@ type InterceptionRecord struct {
 	SessionID string `json:"session_id"`
 	// Sequence is ctx.sequence — total order within the session (§12.2.3).
 	Sequence int64 `json:"sequence"`
+	// Timestamp is the RFC 3339 instant copied from ctx.timestamp
+	// (§10.3); nil when the context lacked the field.
+	Timestamp *string `json:"timestamp,omitempty"`
+	// Trace is the W3C Trace Context correlation echoed from the
+	// context's optional trace block (§4.5); nil when the context
+	// carried none.
+	Trace *TraceContext `json:"trace,omitempty"`
 	// DecidedBy is the registration index of the interceptor whose
 	// verdict won the aggregation or whose liftable deny was consulted
 	// (§7.6); nil for a pure-allow combination or a host-synthesized

--- a/sdk/python/python/agent_hooks/_types.py
+++ b/sdk/python/python/agent_hooks/_types.py
@@ -407,6 +407,13 @@ class InterceptionRecord:
     session_id: str = ""
     #: ``ctx.sequence`` — total order within the session (§12.2.3).
     sequence: int = -1
+    #: RFC 3339 instant copied from ``ctx.timestamp`` (§10.3); ``None``
+    #: when the context lacked the field.
+    timestamp: str | None = None
+    #: W3C Trace Context correlation echoed from the context's optional
+    #: ``trace`` block (§4.5): ``{"trace_id": ..., "span_id": ...}``;
+    #: ``None`` when the context carried none.
+    trace: dict[str, str] | None = None
     #: Registration index of the interceptor whose verdict won the
     #: aggregation or whose liftable deny was consulted (§7.6); ``None``
     #: for a pure-allow combination or a host-synthesized verdict.
@@ -453,6 +460,10 @@ class InterceptionRecord:
             "decided_by": self.decided_by,
             "composition": self.composition.to_wire(),
         }
+        if self.timestamp is not None:
+            out["timestamp"] = self.timestamp
+        if self.trace is not None:
+            out["trace"] = dict(self.trace)
         if self.verdicts:
             out["verdicts"] = [v.to_wire() for v in self.verdicts]
         if self.fold_truncated is not None:
@@ -474,6 +485,8 @@ class InterceptionRecord:
             identity_provider=obj.get("identity_provider"),
             session_id=obj.get("session_id", ""),
             sequence=obj.get("sequence", -1),
+            timestamp=obj.get("timestamp"),
+            trace=obj.get("trace"),
             decided_by=obj.get("decided_by"),
             composition=CompositionConfig.from_wire(obj.get("composition")),
             verdicts=tuple(VerdictSummary.from_wire(v) for v in obj.get("verdicts") or ()),

--- a/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-081-run-all-aggregate.json
+++ b/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-081-run-all-aggregate.json
@@ -108,7 +108,13 @@
           "verdicts[0].decision": "transform",
           "verdicts[1].decision": "deny",
           "verdicts[2].decision": "allow"
-        }
+        },
+        "present": [
+          "timestamp"
+        ],
+        "absent": [
+          "trace"
+        ]
       }
     ],
     "run_outcome": "completed"

--- a/sdk/python/python/agent_hooks/schema/interception-record.schema.json
+++ b/sdk/python/python/agent_hooks/schema/interception-record.schema.json
@@ -101,6 +101,23 @@
       "type": "integer",
       "description": "ctx.sequence — total order of records within the session (§12.2.3)."
     },
+    "timestamp": {
+      "type": "string",
+      "description": "OPTIONAL. The context's RFC 3339 timestamp, copied verbatim (§10.3); absent when the context lacked the field."
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "trace_id": {
+          "type": "string"
+        },
+        "span_id": {
+          "type": "string"
+        }
+      },
+      "description": "OPTIONAL. W3C Trace Context identifiers echoed from the context's optional trace block (§4.5, §10.3); absent when the context carried neither member."
+    },
     "decided_by": {
       "type": [
         "integer",

--- a/sdk/rust/core/src/ctk_engine.rs
+++ b/sdk/rust/core/src/ctk_engine.rs
@@ -376,7 +376,9 @@ fn assert_identities(expect: &Value, rr: &RunRecord, failures: &mut Vec<String>)
 /// dotted-path assertions against the wire-shaped record (§10.3). A
 /// path that does not resolve is a failure — assert only fields the
 /// record is expected to carry (absent-when-None fields like
-/// `fold_truncated` are simply not asserted when absent).
+/// `fold_truncated` are simply not asserted when absent). `present`
+/// asserts a path resolves without pinning its (possibly dynamic)
+/// value — e.g. the record `timestamp`.
 fn assert_records(expect: &Value, rr: &RunRecord, failures: &mut Vec<String>) {
     let Some(expected) = expect.get("records").and_then(Value::as_array) else {
         return;
@@ -418,6 +420,15 @@ fn assert_records(expect: &Value, rr: &RunRecord, failures: &mut Vec<String>) {
                 if let Some(got) = lookup(rec, path) {
                     failures.push(format!(
                         "record[{ri}] {want_ip}: {path} present ({got}), want absent"
+                    ));
+                }
+            }
+        }
+        if let Some(present) = e.get("present").and_then(Value::as_array) {
+            for path in present.iter().filter_map(Value::as_str) {
+                if lookup(rec, path).is_none() {
+                    failures.push(format!(
+                        "record[{ri}] {want_ip}: {path} absent, want present"
                     ));
                 }
             }

--- a/sdk/rust/core/src/enforce.rs
+++ b/sdk/rust/core/src/enforce.rs
@@ -376,7 +376,10 @@ mod tests {
             default_meta(&ctx("pre_tool_call", json!({"url": "x"}))),
         ))
         .unwrap();
-        assert!(wire.get("trace").is_none(), "trace absent without context trace");
+        assert!(
+            wire.get("trace").is_none(),
+            "trace absent without context trace"
+        );
         assert!(wire.get("timestamp").is_some());
     }
 

--- a/sdk/rust/core/src/enforce.rs
+++ b/sdk/rust/core/src/enforce.rs
@@ -195,6 +195,19 @@ pub fn finalize(
         .unwrap_or_default()
         .to_owned();
     let sequence = ctx.get("sequence").and_then(Value::as_i64).unwrap_or(-1);
+    // §10.3: payload-free copies for audit/SIEM correlation. String
+    // members only; a malformed envelope simply yields absence.
+    let timestamp = ctx
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let trace = ctx.get("trace").and_then(Value::as_object).and_then(|t| {
+        let tc = crate::types::TraceContext {
+            trace_id: t.get("trace_id").and_then(Value::as_str).map(str::to_owned),
+            span_id: t.get("span_id").and_then(Value::as_str).map(str::to_owned),
+        };
+        (tc.trace_id.is_some() || tc.span_id.is_some()).then_some(tc)
+    });
     let enforced_identity = match meta.identity_provider.as_deref() {
         _ if envelope_invalid.is_some() => None,
         Some(JCS_SHA256) if meta.jcs_input_rejected => {
@@ -257,6 +270,8 @@ pub fn finalize(
         identity_provider: meta.identity_provider,
         session_id,
         sequence,
+        timestamp,
+        trace,
         decided_by,
         composition: meta.composition.with_knob_defaults(),
         verdicts: meta.verdicts,
@@ -331,6 +346,51 @@ mod tests {
             identity_provider: Some(JCS_SHA256.to_owned()),
             ..FinalizeMeta::default()
         }
+    }
+
+    #[test]
+    fn record_copies_timestamp_and_echoes_trace() {
+        let mut c = ctx("pre_tool_call", json!({"url": "x"}));
+        c.insert(
+            "trace".into(),
+            json!({"trace_id": "0af7651916cd43dd8448eb211c80319c", "span_id": "b7ad6b7169203331"}),
+        );
+        let r = finalize(
+            &c,
+            Verdict::allow(),
+            EnforcementMode::Enforce,
+            default_meta(&c),
+        );
+        assert_eq!(r.timestamp.as_deref(), Some("2026-01-01T00:00:00Z"));
+        let t = r.trace.expect("trace echoed");
+        assert_eq!(
+            t.trace_id.as_deref(),
+            Some("0af7651916cd43dd8448eb211c80319c")
+        );
+        assert_eq!(t.span_id.as_deref(), Some("b7ad6b7169203331"));
+        // wire shape: absent-when-None members
+        let wire = serde_json::to_value(finalize(
+            &ctx("pre_tool_call", json!({"url": "x"})),
+            Verdict::allow(),
+            EnforcementMode::Enforce,
+            default_meta(&ctx("pre_tool_call", json!({"url": "x"}))),
+        ))
+        .unwrap();
+        assert!(wire.get("trace").is_none(), "trace absent without context trace");
+        assert!(wire.get("timestamp").is_some());
+    }
+
+    #[test]
+    fn trace_with_foreign_members_only_is_absent() {
+        let mut c = ctx("pre_tool_call", json!({"url": "x"}));
+        c.insert("trace".into(), json!({"vendor": "x"}));
+        let r = finalize(
+            &c,
+            Verdict::allow(),
+            EnforcementMode::Enforce,
+            default_meta(&c),
+        );
+        assert!(r.trace.is_none());
     }
 
     #[test]

--- a/sdk/rust/core/src/ffi_surface.rs
+++ b/sdk/rust/core/src/ffi_surface.rs
@@ -283,7 +283,9 @@ pub fn finalize(
         Some(other) => {
             return Err(err(
                 HostError::ContextInvalid,
-                format!("options.resolved_by: {other:?} (want \"approval\" | \"rejection\" | null)"),
+                format!(
+                    "options.resolved_by: {other:?} (want \"approval\" | \"rejection\" | null)"
+                ),
             ))
         }
     };
@@ -533,13 +535,13 @@ mod tests {
         // LATER-07 / AR-09-005: each of these previously truncated or
         // silently dropped; all must now fail loudly at the boundary.
         for (k, v) in [
-            ("decided_by", json!(4294967296_u64)),   // > u32::MAX: was wrapping
-            ("decided_by", json!(-1)),               // negative: was None
-            ("decided_by", json!("2")),              // string: was None
-            ("input_identity", json!(42)),           // non-string: was dropped
-            ("identity_provider", json!(7)),         // non-string: was dropped
-            ("resolved_by", json!("bogus")),         // unknown value: was None
-            ("fold_truncated", json!("yes")),        // non-bool: was None
+            ("decided_by", json!(4294967296_u64)), // > u32::MAX: was wrapping
+            ("decided_by", json!(-1)),             // negative: was None
+            ("decided_by", json!("2")),            // string: was None
+            ("input_identity", json!(42)),         // non-string: was dropped
+            ("identity_provider", json!(7)),       // non-string: was dropped
+            ("resolved_by", json!("bogus")),       // unknown value: was None
+            ("fold_truncated", json!("yes")),      // non-bool: was None
         ] {
             let mut o = base.clone();
             o[k] = v.clone();

--- a/sdk/rust/core/src/ffi_surface.rs
+++ b/sdk/rust/core/src/ffi_surface.rs
@@ -246,56 +246,67 @@ pub fn finalize(
         "evaluate_only" => EnforcementMode::EvaluateOnly,
         _ => return Err(err(HostError::ContextInvalid, format!("mode: {mode}"))),
     };
-    let opts: Value = parse_json(options_json, "options")?;
-    let composition: CompositionConfig = serde_json::from_value(
-        opts.get("composition").cloned().unwrap_or(Value::Null),
-    )
-    .map_err(|e| {
-        err(
-            HostError::ContextInvalid,
-            format!("options.composition: {e}"),
-        )
-    })?;
-    let verdicts = match opts.get("verdicts") {
-        None | Some(Value::Null) => Vec::new(),
-        Some(v) => serde_json::from_value(v.clone())
-            .map_err(|e| err(HostError::ContextInvalid, format!("options.verdicts: {e}")))?,
+    // Typed, strict options parsing (LATER-07 / AR-09-005): a value
+    // above u32::MAX, a negative index, or a mistyped identity field
+    // fails loudly at the boundary instead of truncating or dropping
+    // silently into the audit record. Unknown members remain ignored
+    // (forward compatibility); known members must have their exact
+    // types.
+    #[derive(serde::Deserialize)]
+    struct FinalizeOptions {
+        #[serde(default)]
+        input_identity: Option<String>,
+        #[serde(default)]
+        identity_provider: Option<String>,
+        #[serde(default)]
+        enforced_identity: Option<String>,
+        #[serde(default)]
+        decided_by: Option<u32>,
+        composition: CompositionConfig,
+        #[serde(default)]
+        verdicts: Option<Vec<crate::types::VerdictSummary>>,
+        #[serde(default)]
+        fold_truncated: Option<bool>,
+        #[serde(default)]
+        resolved_by: Option<String>,
+        #[serde(default)]
+        unchanged_since_input: bool,
+        #[serde(default)]
+        interceptors_registered: u32,
+    }
+    let opts: FinalizeOptions = serde_json::from_str(options_json)
+        .map_err(|e| err(HostError::ContextInvalid, format!("options: {e}")))?;
+    let resolved_by = match opts.resolved_by.as_deref() {
+        None => None,
+        Some("approval") => Some("approval"),
+        Some("rejection") => Some("rejection"),
+        Some(other) => {
+            return Err(err(
+                HostError::ContextInvalid,
+                format!("options.resolved_by: {other:?} (want \"approval\" | \"rejection\" | null)"),
+            ))
+        }
     };
-    let opt_str = |k: &str| opts.get(k).and_then(Value::as_str).map(str::to_owned);
     // jcs-sha256 computes enforced_identity core-side from this ctx,
     // but the parse above already coerced any beyond-u64 literal — so
     // when the raw-text scan rejects, identity computation is
     // suppressed (null identities, §10.3 rejection shape) rather than
     // hashing the rounded bytes. Never an error here: finalize builds
     // the fail-closed record for exactly these contexts.
-    let jcs_input_rejected = opt_str("identity_provider").as_deref() == Some("jcs-sha256")
+    let jcs_input_rejected = opts.identity_provider.as_deref() == Some("jcs-sha256")
         && canonical::scan_projection_raw(ctx_json).is_err();
-    let unchanged_since_input = opts
-        .get("unchanged_since_input")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
     let meta = FinalizeMeta {
-        input_identity: opt_str("input_identity"),
-        identity_provider: opt_str("identity_provider"),
-        enforced_identity: opt_str("enforced_identity"),
+        input_identity: opts.input_identity,
+        identity_provider: opts.identity_provider,
+        enforced_identity: opts.enforced_identity,
         jcs_input_rejected,
-        unchanged_since_input,
-        decided_by: opts
-            .get("decided_by")
-            .and_then(Value::as_u64)
-            .map(|d| d as u32),
-        composition,
-        verdicts,
-        fold_truncated: opts.get("fold_truncated").and_then(Value::as_bool),
-        resolved_by: match opts.get("resolved_by").and_then(Value::as_str) {
-            Some("approval") => Some("approval"),
-            Some("rejection") => Some("rejection"),
-            _ => None,
-        },
-        interceptors_registered: opts
-            .get("interceptors_registered")
-            .and_then(Value::as_u64)
-            .unwrap_or(0) as u32,
+        unchanged_since_input: opts.unchanged_since_input,
+        decided_by: opts.decided_by,
+        composition: opts.composition,
+        verdicts: opts.verdicts.unwrap_or_default(),
+        fold_truncated: opts.fold_truncated,
+        resolved_by,
+        interceptors_registered: opts.interceptors_registered,
     };
     // §10.1: a host-defined provider name must satisfy the name rules;
     // a wrapper that lets "jcs-fake" through would let records claim
@@ -506,6 +517,64 @@ mod tests {
         assert_eq!(r["identity_provider"], "jcs-sha256");
         assert_eq!(r["composition"]["profile"], "sequential/first_deny");
         assert_eq!(r["fold_truncated"], false);
+    }
+
+    #[test]
+    fn finalize_options_strict_types() {
+        let ctx = json!({
+            "spec": "agent-hooks/0.1", "interception_point": "input",
+            "timestamp": "t", "sequence": 0,
+            "agent": {"id": "a", "framework": "x"}, "session": {"id": "s"},
+            "target": {"content": "hi", "role": "user"},
+            "input": {"content": "hi", "role": "user"}
+        })
+        .to_string();
+        let base = json!({"composition": {"profile": "sequential/first_deny"}});
+        // LATER-07 / AR-09-005: each of these previously truncated or
+        // silently dropped; all must now fail loudly at the boundary.
+        for (k, v) in [
+            ("decided_by", json!(4294967296_u64)),   // > u32::MAX: was wrapping
+            ("decided_by", json!(-1)),               // negative: was None
+            ("decided_by", json!("2")),              // string: was None
+            ("input_identity", json!(42)),           // non-string: was dropped
+            ("identity_provider", json!(7)),         // non-string: was dropped
+            ("resolved_by", json!("bogus")),         // unknown value: was None
+            ("fold_truncated", json!("yes")),        // non-bool: was None
+        ] {
+            let mut o = base.clone();
+            o[k] = v.clone();
+            let e = finalize(&ctx, r#"{"decision": "allow"}"#, "enforce", &o.to_string())
+                .expect_err(&format!("options.{k}={v} must be rejected"));
+            assert_eq!(e.0, "host_error:context_invalid", "options.{k}");
+        }
+        // valid u32 boundary still accepted
+        let mut o = base.clone();
+        o["decided_by"] = json!(u32::MAX);
+        finalize(&ctx, r#"{"decision": "allow"}"#, "enforce", &o.to_string()).unwrap();
+    }
+
+    #[test]
+    fn finalize_record_carries_timestamp_and_trace() {
+        let ctx = json!({
+            "spec": "agent-hooks/0.1", "interception_point": "input",
+            "timestamp": "2026-01-01T00:00:00Z", "sequence": 0,
+            "agent": {"id": "a", "framework": "x"}, "session": {"id": "s"},
+            "target": {"content": "hi", "role": "user"},
+            "input": {"content": "hi", "role": "user"},
+            "trace": {"trace_id": "0af7651916cd43dd8448eb211c80319c", "span_id": "b7ad6b7169203331"}
+        })
+        .to_string();
+        let out = finalize(
+            &ctx,
+            r#"{"decision": "allow"}"#,
+            "enforce",
+            &json!({"composition": {"profile": "sequential/first_deny"}}).to_string(),
+        )
+        .unwrap();
+        let r: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(r["timestamp"], "2026-01-01T00:00:00Z");
+        assert_eq!(r["trace"]["trace_id"], "0af7651916cd43dd8448eb211c80319c");
+        assert_eq!(r["trace"]["span_id"], "b7ad6b7169203331");
     }
 
     #[test]

--- a/sdk/rust/core/src/types.rs
+++ b/sdk/rust/core/src/types.rs
@@ -298,6 +298,18 @@ impl Verdict {
 /// the schema without translation; helpers in `canonical.rs` operate on it.
 pub type AgentContext = serde_json::Map<String, Value>;
 
+/// W3C Trace Context correlation echoed onto the record from the
+/// context's optional `trace` block (§4.5, §10.3). Payload-free:
+/// identifiers only. Lets audit/SIEM sinks join records to OTel
+/// spans without host-side stitching.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TraceContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span_id: Option<String>,
+}
+
 /// Payload-free per-interceptor summary on the record (§10.3).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VerdictSummary {
@@ -338,6 +350,15 @@ pub struct InterceptionRecord {
     /// `ctx.sequence` — total order of records within the session
     /// (§12.2.3). `-1` when the context lacked the required field.
     pub sequence: i64,
+    /// RFC 3339 instant copied from `ctx.timestamp` (§10.3); absent
+    /// when the context lacked the field. Gives audit/SIEM sinks an
+    /// event time without payload duplication.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    /// Trace correlation echoed from the context's optional `trace`
+    /// block (§4.5); absent when the context carried none.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace: Option<TraceContext>,
     /// Registration index of the interceptor whose verdict won the
     /// aggregation or whose liftable deny was consulted (§7.6). `None`
     /// for a pure-allow combination or a host-synthesized verdict.

--- a/sdk/rust/core/src/verdict.rs
+++ b/sdk/rust/core/src/verdict.rs
@@ -107,11 +107,18 @@ pub fn from_wire(raw: &Value) -> Result<Verdict, (HostError, String)> {
                 .get("path")
                 .and_then(Value::as_str)
                 .ok_or((HostError::VerdictInvalid, "transform.path missing".into()))?;
-            if !(path.starts_with("$target") || path.starts_with("$policy_target")) {
-                return Err((
-                    HostError::TransformTargetForbidden,
-                    format!("transform.path must be rooted at $target (got {path:?})"),
-                ));
+            // §5 gate and §5.2 application MUST agree byte-for-byte
+            // on the accepted path language: validate with the same
+            // parser apply uses, mapping its error codes through
+            // unchanged (LATER-06 / AR-09-006).
+            if let Err(e) = crate::path::parse(path) {
+                let detail = match e {
+                    HostError::TransformTargetForbidden => {
+                        format!("transform.path must be rooted at $target (got {path:?})")
+                    }
+                    _ => format!("transform.path rejected by the §5.2 grammar (got {path:?})"),
+                };
+                return Err((e, detail));
             }
             // §5.2: value is any JSON value including null; an absent
             // member is equivalent to null (the record projection and
@@ -225,6 +232,35 @@ fn opt_string(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn gate_and_apply_agree_on_path_language() {
+        // near-miss roots the old prefix check accepted (AR-09-006)
+        for (path, want) in [
+            ("$targets.x", crate::types::HostError::TransformInvalid),
+            ("$targetfoo", crate::types::HostError::TransformInvalid),
+            ("$snapshot.x", crate::types::HostError::TransformTargetForbidden),
+            ("$target.", crate::types::HostError::TransformInvalid),
+        ] {
+            let w = serde_json::json!({
+                "decision": "transform",
+                "transform": {"path": path, "value": 1}
+            });
+            let gate = from_wire(&w).expect_err("gate must reject");
+            assert_eq!(gate.0, want, "gate error for {path}");
+            let apply = crate::path::parse(path).expect_err("parse must reject");
+            assert_eq!(gate.0, apply, "gate/apply divergence for {path}");
+        }
+        // the accepted language still passes both layers
+        for path in ["$target", "$target.a", "$target[0]", "$policy_target.a"] {
+            let w = serde_json::json!({
+                "decision": "transform",
+                "transform": {"path": path, "value": 1}
+            });
+            assert!(from_wire(&w).is_ok(), "gate rejects valid {path}");
+            assert!(crate::path::parse(path).is_ok());
+        }
+    }
 
     #[test]
     fn from_wire_allow() {

--- a/sdk/rust/core/src/verdict.rs
+++ b/sdk/rust/core/src/verdict.rs
@@ -239,7 +239,10 @@ mod tests {
         for (path, want) in [
             ("$targets.x", crate::types::HostError::TransformInvalid),
             ("$targetfoo", crate::types::HostError::TransformInvalid),
-            ("$snapshot.x", crate::types::HostError::TransformTargetForbidden),
+            (
+                "$snapshot.x",
+                crate::types::HostError::TransformTargetForbidden,
+            ),
             ("$target.", crate::types::HostError::TransformInvalid),
         ] {
             let w = serde_json::json!({

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -278,6 +278,12 @@ export interface InterceptionRecord {
   session_id: string;
   /** `ctx.sequence` — total order within the session (§12.2.3). */
   sequence: number;
+  /** RFC 3339 instant copied from `ctx.timestamp` (§10.3); absent when
+   * the context lacked the field. */
+  timestamp?: string;
+  /** W3C Trace Context correlation echoed from the context's optional
+   * `trace` block (§4.5); absent when the context carried none. */
+  trace?: { trace_id?: string; span_id?: string };
   /** Registration index of the interceptor whose verdict won the
    * aggregation or whose liftable deny was consulted (§7.6); `null`
    * for a pure-allow combination or a host-synthesized verdict. */

--- a/spec/AGENT-HOOKS-0.1.md
+++ b/spec/AGENT-HOOKS-0.1.md
@@ -1039,6 +1039,8 @@ of the record.
   "identity_provider": "jcs-sha256" | "<host-defined>" | null,
   "session_id": "string",
   "sequence": 0,
+  "timestamp": "2026-06-19T14:03:11.123Z",             // absent when the context lacked it
+  "trace": { "trace_id": "<hex>", "span_id": "<hex>" }, // absent when the context carried none
   "decided_by": 0 | null,
   "composition": {
     "profile": "sequential/first_deny" | "sequential/run_all"
@@ -1060,12 +1062,22 @@ of the record.
 | `enforced_identity` | Provider output after composition completes (post-fold in sequential profiles). Equal to `input_identity` when no transform was applied, and always equal in `evaluate_only` mode. |
 | `identity_provider` | The declared provider (§10.1). |
 | `session_id`, `sequence` | Copied from the context; records are totally ordered within a session. |
+| `timestamp` | OPTIONAL. The context's RFC 3339 `timestamp`, copied verbatim — the event time audit/SIEM sinks index on. Absent when the context lacked the field. |
+| `trace` | OPTIONAL. `{trace_id?, span_id?}` echoed from the context's optional `trace` block (§4.5, W3C Trace Context). Payload-free identifiers only; absent when the context carried neither member. Lets a record join the host's distributed trace without out-of-band stitching. |
 | `decided_by` | Registration index of the interceptor whose verdict won the aggregation (§7.3) or whose liftable deny was consulted (§7.6). A §6.3 failure deny (`interceptor_failed`, `interceptor_timeout`, `verdict_invalid`) carries the **failing interceptor's** index, in every profile. `null` is reserved for pure-allow combinations, §5.2 transform-application failures, and profile-synthesized verdicts (`transform_conflict`, `composition_disagreement`, `no_interceptor`, identity-provider rejection). |
 | `composition` | The profile and knobs in effect (§7.1). REQUIRED. Knob members the profile consults MUST be present with their **resolved** values (the §7.2 defaults filled in when the host left them unset); knobs the profile never consults MUST be absent. |
 | `verdicts` | Payload-free per-interceptor summary `{index, decision, reason?, name?}`. REQUIRED in multi-verdict profiles (`sequential/run_all`, `parallel/*`); OPTIONAL in `sequential/first_deny`. `name` is the host-chosen registration identifier for the interceptor at `index` (§7); it MUST be payload-free. |
 | `fold_truncated` | `true` iff one or more registered interceptors were never invoked in this emission — a first-deny short-circuit, an approval-stop, or a failed fold-transform (§7.4). Defined for the sequential profiles. |
 | `resolved_by` | Consultation outcome (§7.6): `"approval"` iff a permit resolution substituted for a verdict; `"rejection"` iff the seam was consulted and did **not** lift the deny (reject, unresolved, resolver failure, or echo violation); absent iff the seam was never consulted. A record reader can therefore always answer "was a human consulted, and did they permit?". |
 | `interceptors_registered` | Number of interceptors registered at emission time. Together with `verdicts`/`fold_truncated` this makes skipped interceptors detectable from the record alone. |
+
+*Informative — OpenTelemetry alignment.* The optional context fields
+`usage.prompt_tokens`/`usage.completion_tokens` (§4.5) correspond to
+the OTel GenAI semantic-convention attributes `gen_ai.usage.input_tokens`/
+`gen_ai.usage.output_tokens`, and the record's `trace` block carries
+W3C Trace Context identifiers as used by OTel spans. Hosts emitting
+both planes SHOULD map these pairs directly rather than inventing a
+divergent naming.
 
 ---
 

--- a/spec/schema/interception-record.schema.json
+++ b/spec/schema/interception-record.schema.json
@@ -101,6 +101,23 @@
       "type": "integer",
       "description": "ctx.sequence — total order of records within the session (§12.2.3)."
     },
+    "timestamp": {
+      "type": "string",
+      "description": "OPTIONAL. The context's RFC 3339 timestamp, copied verbatim (§10.3); absent when the context lacked the field."
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "trace_id": {
+          "type": "string"
+        },
+        "span_id": {
+          "type": "string"
+        }
+      },
+      "description": "OPTIONAL. W3C Trace Context identifiers echoed from the context's optional trace block (§4.5, §10.3); absent when the context carried neither member."
+    },
     "decided_by": {
       "type": [
         "integer",


### PR DESCRIPTION
Core follow-ups from the 2026-07-09 architectural review.

- **Record timestamp/trace correlation** — `InterceptionRecord` gains optional `timestamp` (RFC 3339, copied from the context) and `trace` `{trace_id, span_id}` (echoed from the context's optional §4.5 block): payload-free copies giving audit/SIEM sinks an event time and an OTel trace join. Spec §10.3 documents both plus an informative `gen_ai.usage.*` alignment note. Schema, all five SDK record types, and vendored copies updated. The CTK engine gains `present` record assertions for dynamic-valued fields; AH-CTK-081 pins timestamp presence and trace absence.
- **Gate/parser unification** — the §5 verdict gate validates `transform.path` with the same parser §5.2 application uses: near-miss roots (`$targets.x`) that the old prefix check accepted now fail at the gate with the same error code apply would raise; tests pin gate/apply agreement across the accepted path language.
- **Typed finalize options** — `ah_finalize` options parse into a typed struct: `decided_by` beyond u32::MAX, negative or mistyped values, non-string identity fields, and unknown `resolved_by` values fail loudly as `host_error:context_invalid` instead of truncating or silently dropping into the audit record.

Local matrix: Rust 99 lib + CTK/golden suites, clippy clean; Python 175, ruff clean; TypeScript 122; .NET 116; gofmt clean (Go compile via CI). Schema-lint replicated locally (all schemas compile, 36 vectors valid); drift regeneration replicated.
