### PR TITLE
ci: dispatch input to bootstrap the npm platform packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,15 @@ on:
         description: Build and attest everything, skip all uploads
         type: boolean
         default: true
+      bootstrap_platform_packages:
+        description: >-
+          One-time bootstrap: publish the npm platform packages from a
+          dispatch run (they cannot use trusted publishing before their
+          first publish). Requires the NPM_TOKEN environment secret and
+          dry_run=false. Only the platform-package step is enabled;
+          every other publish remains tag-gated.
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -195,7 +204,7 @@ jobs:
             sdk/typescript/*.tgz
             sdk/typescript/npm/**/*.node
       - name: Publish to npm (platform packages, then the loader package)
-        if: env.DRY_RUN != 'true' && github.ref_type == 'tag'
+        if: env.DRY_RUN != 'true' && (github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.bootstrap_platform_packages))
         # OIDC trusted publishing: no token. Each PACKAGE (the four
         # platform packages and the main one) needs its own trusted
         # publisher on npmjs.com (repo responsibleai/agent-hooks,


### PR DESCRIPTION
A package's first publish cannot use npm trusted publishing, and every publish step requires a tag ref — so the four platform packages have no path to their initial release. Adds a `bootstrap_platform_packages` dispatch input that enables only the platform-package publish step (still environment-protected, using the temporary `NPM_TOKEN` secret); every other publish remains tag-gated. The input is one-time-use by nature: after the bootstrap, per-package trusted publishers take over and the secret is deleted.