### PR TITLE
ci: correct the download-artifact action pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with: { node-version: "22", registry-url: "https://registry.npmjs.org" }
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: sdk/typescript/artifacts
       - name: Distribute binaries into platform packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with: { node-version: "22", registry-url: "https://registry.npmjs.org" }
-      - uses: actions/download-artifact@d8a25596c31467f6dbf29b78082a2ecba9834b45 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 # v7.0.0
         with:
           path: sdk/typescript/artifacts
       - name: Distribute binaries into platform packages


### PR DESCRIPTION
The release dry-run's typescript job failed at setup: the pinned `actions/download-artifact` SHA does not exist in that repository. Re-pinned to the real v8.0.1 commit resolved from its tags. All 15 action pins across both workflows were audited; this was the only unresolvable one.