### PR TITLE
sdk/typescript: platform packages describe themselves

### DIFF
--- a/sdk/typescript/npm/darwin-arm64/package.json
+++ b/sdk/typescript/npm/darwin-arm64/package.json
@@ -8,7 +8,7 @@
   "files": [
     "agent-hooks.darwin-arm64.node"
   ],
-  "description": "Framework-neutral agent control contract (AGENT-HOOKS-0.1). TypeScript wrapper over the canonical Rust core. Cooperative contract, not a security boundary: the host is fully trusted (see SECURITY.md).",
+  "description": "Prebuilt darwin-arm64 native binary for @responsibleai/agent-hooks.",
   "license": "MIT",
   "engines": {
     "node": ">=20"

--- a/sdk/typescript/npm/darwin-x64/package.json
+++ b/sdk/typescript/npm/darwin-x64/package.json
@@ -8,7 +8,7 @@
   "files": [
     "agent-hooks.darwin-x64.node"
   ],
-  "description": "Framework-neutral agent control contract (AGENT-HOOKS-0.1). TypeScript wrapper over the canonical Rust core. Cooperative contract, not a security boundary: the host is fully trusted (see SECURITY.md).",
+  "description": "Prebuilt darwin-x64 native binary for @responsibleai/agent-hooks.",
   "license": "MIT",
   "engines": {
     "node": ">=20"

--- a/sdk/typescript/npm/linux-x64-gnu/package.json
+++ b/sdk/typescript/npm/linux-x64-gnu/package.json
@@ -8,7 +8,7 @@
   "files": [
     "agent-hooks.linux-x64-gnu.node"
   ],
-  "description": "Framework-neutral agent control contract (AGENT-HOOKS-0.1). TypeScript wrapper over the canonical Rust core. Cooperative contract, not a security boundary: the host is fully trusted (see SECURITY.md).",
+  "description": "Prebuilt linux-x64-gnu native binary for @responsibleai/agent-hooks.",
   "license": "MIT",
   "engines": {
     "node": ">=20"

--- a/sdk/typescript/npm/win32-x64-msvc/package.json
+++ b/sdk/typescript/npm/win32-x64-msvc/package.json
@@ -8,7 +8,7 @@
   "files": [
     "agent-hooks.win32-x64-msvc.node"
   ],
-  "description": "Framework-neutral agent control contract (AGENT-HOOKS-0.1). TypeScript wrapper over the canonical Rust core. Cooperative contract, not a security boundary: the host is fully trusted (see SECURITY.md).",
+  "description": "Prebuilt win32-x64-msvc native binary for @responsibleai/agent-hooks.",
   "license": "MIT",
   "engines": {
     "node": ">=20"

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -15,6 +15,12 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@responsibleai/agent-hooks-darwin-arm64": "0.1.0-alpha.2",
+        "@responsibleai/agent-hooks-darwin-x64": "0.1.0-alpha.2",
+        "@responsibleai/agent-hooks-linux-x64-gnu": "0.1.0-alpha.2",
+        "@responsibleai/agent-hooks-win32-x64-msvc": "0.1.0-alpha.2"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1602,6 +1608,73 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@responsibleai/agent-hooks-darwin-arm64": {
+      "version": "0.1.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@responsibleai/agent-hooks-darwin-arm64/-/agent-hooks-darwin-arm64-0.1.0-alpha.2.tgz",
+      "integrity": "sha512-5Z65HqcysSiJeoNTv2l2VSWE+cIbSWVSe8IWTosz57wNl8LdkcNbgwQhWZNg9+J0FvRxxVejfNzREuKLIS7SVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@responsibleai/agent-hooks-darwin-x64": {
+      "version": "0.1.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@responsibleai/agent-hooks-darwin-x64/-/agent-hooks-darwin-x64-0.1.0-alpha.2.tgz",
+      "integrity": "sha512-+L+G1sbZN8HyPbyzL6uJ6YG7utqrmRfoD2Oa8PbDHKaGSPKEvSqY5MNyT4lpmMU12i6sLTsGEwEllGiYdTm0Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@responsibleai/agent-hooks-linux-x64-gnu": {
+      "version": "0.1.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@responsibleai/agent-hooks-linux-x64-gnu/-/agent-hooks-linux-x64-gnu-0.1.0-alpha.2.tgz",
+      "integrity": "sha512-7pSqVjTfsOuhCA3tVtgUD6/VG4RuXN86QOA4J+LYnGHHYL0jIbIvviNrCyeId3JPWijyThLLgQLAGCJeXiRTxA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@responsibleai/agent-hooks-win32-x64-msvc": {
+      "version": "0.1.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@responsibleai/agent-hooks-win32-x64-msvc/-/agent-hooks-win32-x64-msvc-0.1.0-alpha.2.tgz",
+      "integrity": "sha512-bE9THeVW0JOJN7Gny+69awVyPvri1wljQqy2d9nwfuuka8V5NwmBp6DF/wxrFSBDxhBDboE4wEzgyuwjNS/uGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@tybys/wasm-util": {


### PR DESCRIPTION
The four npm platform packages inherited the loader package's description; each now states which prebuilt native binary it carries. Takes effect on their next published version.