### PR TITLE
release: 0.1.0-alpha.3 — external-consumer feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,28 @@
 User-visible changes to the spec and SDKs. Versioning rules:
 [VERSIONING.md](VERSIONING.md).
 
-## 0.1.0-alpha.2 — unreleased (pending tag `v0.1.0-alpha.2`)
+## 0.1.0-alpha.3
+
+Additive; driven by the first external consumer of the contract (a
+policy decision runtime implementing the interceptor side).
+
+- **Rust: out-of-crate CTK harnesses.** `agent_hooks::ctk` re-exports
+  every type the `Harness` trait signatures reference (`RunRecord`,
+  `VectorResult`, `IdentityPair`) plus `async_trait`, so third-party
+  hosts can implement the trait and run the corpus under their own
+  adapter name. A compile-and-run test pins the seam.
+- **Rust: `InterceptionPoint` derives `Ord`/`PartialOrd`** (declaration
+  order = the §3 lifecycle order, documented on the enum) **and
+  implements `Display`** (wire name). The other SDKs already expose
+  wire-string point types and needed no change.
+- **Docs: decision runtimes behind an interceptor.** Crate-level
+  rustdoc and the README now state the reason-namespace convention:
+  engine-internal failures surface as fail-closed denies under the
+  engine's own namespace (`runtime_error:*` by convention), never
+  `host_error:*`, which is host-reserved (§11) and rejected by §5
+  validation.
+
+## 0.1.0-alpha.2 — tag `v0.1.0-alpha.2`
 
 Contract redesign relative to alpha.1 (breaking; the spec remains
 `agent-hooks/0.1` — pre-release drafts within the 0.1 window are not

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ and [`conformance/HARNESS.md`](conformance/HARNESS.md).
 **Interceptor:** implement `Interceptor.intercept(AgentContext) -> Verdict`
 in any SDK; register with the host.
 
+**Decision runtime behind an interceptor** (a policy engine the
+interceptor delegates to): report engine-internal failures as ordinary
+fail-closed denies under your own reason namespace — the convention is
+`runtime_error:<code>` — never `host_error:*`, which is reserved for
+host-synthesized verdicts (§11) and rejected by §5 validation if an
+interceptor emits it.
+
 **Running it in production:** read [`docs/PRODUCTION.md`](docs/PRODUCTION.md)
 (the decisions to make consciously) and [`docs/OPERATIONS.md`](docs/OPERATIONS.md)
 (failure reasons, rollout, alerting) first.

--- a/sdk/dotnet/Directory.Build.props
+++ b/sdk/dotnet/Directory.Build.props
@@ -8,7 +8,7 @@
     <Authors>Responsible AI</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/responsibleai/agent-hooks</RepositoryUrl>
-    <Version>0.1.0-alpha.2</Version>
+    <Version>0.1.0-alpha.3</Version>
     <!-- Supply chain: lock NuGet resolution; CI restores in locked mode. -->
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-hooks-python"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "agent-hooks-sdk",
  "pyo3",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "agent-hooks-sdk"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-hooks-python"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 license = "MIT"
 description = "PyO3 bindings for the agent-hooks Rust core."

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 # similarity check blocks all separator variants (incl. agenthooks).
 # Import name stays agent_hooks.
 name = "agent-hooks-sdk"
-version = "0.1.0a2"
+version = "0.1.0a3"
 description = "Framework-neutral agent control contract: interception points, agent context, verdict, and conformance test kit. Python wrapper over the canonical Rust core. Cooperative contract, not a security boundary: the host is fully trusted (see SECURITY.md)."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -4,14 +4,14 @@ version = 3
 
 [[package]]
 name = "agent-hooks-ffi"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "agent-hooks-sdk",
 ]
 
 [[package]]
 name = "agent-hooks-sdk"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "async-trait",
  "criterion",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["core", "ffi"]
 
 [workspace.package]
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/sdk/rust/core/src/ctk.rs
+++ b/sdk/rust/core/src/ctk.rs
@@ -10,17 +10,19 @@
 //! [`ReferenceHarness`] is the CTK self-test target.
 
 use crate::composition::CompositionConfig;
-use crate::ctk_engine::{
-    assert_vector, scripted_intercept, scripted_resolve, should_skip, IdentityPair, RunRecord,
-    VectorResult,
-};
+use crate::ctk_engine::{assert_vector, scripted_intercept, scripted_resolve, should_skip};
+// Public seam for out-of-crate `Harness` implementors: every type the
+// trait's signatures reference is importable from `agent_hooks::ctk`,
+// and `async_trait` is re-exported so implementors don't need the
+// dependency themselves.
+pub use crate::ctk_engine::{IdentityPair, RunRecord, VectorResult};
 use crate::emitter::{IdentityProvider, InterceptionBlocked, InterceptionEmitter};
 use crate::types::{
     AgentContext, ApprovalRequest, ApprovalResolution, ApprovalResolver, EnforcementMode,
     Interceptor, Verdict,
 };
 use crate::AgentContextBuilder;
-use async_trait::async_trait;
+pub use async_trait::async_trait;
 use serde_json::{json, Value};
 use std::path::Path;
 use std::sync::{Arc, Mutex};

--- a/sdk/rust/core/src/lib.rs
+++ b/sdk/rust/core/src/lib.rs
@@ -28,6 +28,25 @@
 //! certification. See
 //! [SECURITY.md](https://github.com/responsibleai/agent-hooks/blob/main/SECURITY.md)
 //! and [spec §1.4](https://github.com/responsibleai/agent-hooks/blob/main/spec/AGENT-HOOKS-0.1.md#14-trust-model-and-non-goals).
+//!
+//! # Decision runtimes behind an interceptor
+//!
+//! A policy engine (or any decision runtime) that sits *behind* an
+//! interceptor is neither a host nor the interceptor itself, and its
+//! internal failures need a reason namespace:
+//!
+//! - `host_error:*` is reserved for **host-synthesized** verdicts (§11).
+//!   An interceptor — including one that wraps an engine — MUST NOT
+//!   emit it; the §5 gate rejects such verdicts as `verdict_invalid`.
+//! - An engine therefore reports its own failures under its own
+//!   namespace (the convention consumers use is `runtime_error:*`),
+//!   returned as an ordinary fail-closed `deny` verdict:
+//!   `{"decision": "deny", "reason": "runtime_error:<code>"}`.
+//! - Engine failures are the interceptor's to convert. Only if the
+//!   interceptor itself raises or times out does the *host* synthesize
+//!   `host_error:interceptor_failed` / `host_error:interceptor_timeout`
+//!   (§6.3) — at which point the engine's detail is gone, so convert,
+//!   don't panic.
 
 #![warn(clippy::all)]
 

--- a/sdk/rust/core/src/types.rs
+++ b/sdk/rust/core/src/types.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
+use std::fmt;
 
 /// Spec version this crate implements (§4.1 `spec` field).
 pub const SPEC_VERSION: &str = "agent-hooks/0.1";
@@ -37,7 +38,11 @@ pub fn validate_provider_name(name: &str) -> Result<(), (HostError, String)> {
 }
 
 /// The closed set of agent lifecycle interception points (§3).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+///
+/// `Ord` follows declaration order, which is the §3 lifecycle order
+/// (`agent_startup` < `input` < … < `agent_shutdown`) — NOT
+/// lexicographic wire-name order. `Display` prints the wire name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum InterceptionPoint {
     AgentStartup,
@@ -68,6 +73,13 @@ impl InterceptionPoint {
     /// Whether a `transform` verdict is permitted at this point (§3, §4.3).
     pub fn transform_permitted(self) -> bool {
         !matches!(self, Self::AgentStartup | Self::AgentShutdown)
+    }
+}
+
+impl fmt::Display for InterceptionPoint {
+    /// The wire name (`pre_tool_call`, …).
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 

--- a/sdk/rust/core/tests/ctk_external_harness.rs
+++ b/sdk/rust/core/tests/ctk_external_harness.rs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//! An out-of-crate `ctk::Harness` implementor compiles and runs a
+//! vector: every type the trait's signatures reference is importable
+//! from `agent_hooks::ctk` (§13.2), so third-party hosts can run the
+//! corpus under their own adapter name.
+#![cfg(feature = "ctk")]
+
+use agent_hooks::ctk::{async_trait, run_vector, Harness, RunRecord, VectorSetup};
+use serde_json::json;
+
+/// Deliberately NOT the in-tree ReferenceHarness: a minimal external
+/// adapter that emits nothing and reports an empty session.
+struct ExternalHarness;
+
+#[async_trait]
+impl Harness for ExternalHarness {
+    fn name(&self) -> &str {
+        "external-compile-proof"
+    }
+
+    fn capabilities(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    fn setup(&mut self, _setup: VectorSetup) {}
+
+    async fn run(&mut self) -> RunRecord {
+        RunRecord {
+            outcome: "completed".into(),
+            final_output: json!(null),
+            tool_invocations: Vec::new(),
+            error: None,
+            identities: Vec::new(),
+            records: Vec::new(),
+        }
+    }
+
+    fn teardown(&mut self) {}
+}
+
+#[tokio::test]
+async fn external_harness_runs_a_vector() {
+    // A capability-gated vector: the empty capability set skips it,
+    // which proves setup/run/teardown wire through without needing a
+    // full mock agent here.
+    let vector = json!({
+        "id": "EXTERNAL-SMOKE",
+        "title": "external implementor smoke",
+        "part": "harness_seam",
+        "capabilities": ["model_calls"],
+        "scenario": {},
+        "interceptor_scripts": [],
+        "expect": {}
+    });
+    let mut h = ExternalHarness;
+    let result = run_vector(&mut h, &vector).await;
+    assert_eq!(result.status, "skip");
+    assert_eq!(result.id, "EXTERNAL-SMOKE");
+}

--- a/sdk/typescript/Cargo.lock
+++ b/sdk/typescript/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-hooks-node"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "agent-hooks-sdk",
  "napi",
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "agent-hooks-sdk"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/sdk/typescript/Cargo.toml
+++ b/sdk/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-hooks-node"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 license = "MIT"
 description = "napi-rs bindings for the agent-hooks Rust core."

--- a/sdk/typescript/binding.js
+++ b/sdk/typescript/binding.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-android-arm64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-android-arm-eabi')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-win32-x64-gnu')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-win32-x64-msvc')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-win32-ia32-msvc')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-win32-arm64-msvc')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@responsibleai/agent-hooks-darwin-universal')
       const bindingPackageVersion = require('@responsibleai/agent-hooks-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-darwin-x64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-darwin-arm64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-freebsd-x64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-freebsd-arm64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-x64-musl')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-x64-gnu')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-arm64-musl')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-arm64-gnu')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-arm-musleabihf')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-loong64-musl')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-loong64-gnu')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-riscv64-musl')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-riscv64-gnu')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-linux-ppc64-gnu')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-linux-s390x-gnu')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-openharmony-arm64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-openharmony-x64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-openharmony-arm')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdk/typescript/npm/darwin-arm64/package.json
+++ b/sdk/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responsibleai/agent-hooks-darwin-arm64",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "cpu": [
     "arm64"
   ],

--- a/sdk/typescript/npm/darwin-x64/package.json
+++ b/sdk/typescript/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responsibleai/agent-hooks-darwin-x64",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "cpu": [
     "x64"
   ],

--- a/sdk/typescript/npm/linux-x64-gnu/package.json
+++ b/sdk/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responsibleai/agent-hooks-linux-x64-gnu",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "cpu": [
     "x64"
   ],

--- a/sdk/typescript/npm/win32-x64-msvc/package.json
+++ b/sdk/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responsibleai/agent-hooks-win32-x64-msvc",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "cpu": [
     "x64"
   ],

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@responsibleai/agent-hooks",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@responsibleai/agent-hooks",
-      "version": "0.1.0-alpha.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^3.7.2",
@@ -17,10 +17,10 @@
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@responsibleai/agent-hooks-darwin-arm64": "0.1.0-alpha.2",
-        "@responsibleai/agent-hooks-darwin-x64": "0.1.0-alpha.2",
-        "@responsibleai/agent-hooks-linux-x64-gnu": "0.1.0-alpha.2",
-        "@responsibleai/agent-hooks-win32-x64-msvc": "0.1.0-alpha.2"
+        "@responsibleai/agent-hooks-darwin-arm64": "0.1.0-alpha.3",
+        "@responsibleai/agent-hooks-darwin-x64": "0.1.0-alpha.3",
+        "@responsibleai/agent-hooks-linux-x64-gnu": "0.1.0-alpha.3",
+        "@responsibleai/agent-hooks-win32-x64-msvc": "0.1.0-alpha.3"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1611,71 +1611,16 @@
       }
     },
     "node_modules/@responsibleai/agent-hooks-darwin-arm64": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@responsibleai/agent-hooks-darwin-arm64/-/agent-hooks-darwin-arm64-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-5Z65HqcysSiJeoNTv2l2VSWE+cIbSWVSe8IWTosz57wNl8LdkcNbgwQhWZNg9+J0FvRxxVejfNzREuKLIS7SVw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=20"
-      }
+      "optional": true
     },
     "node_modules/@responsibleai/agent-hooks-darwin-x64": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@responsibleai/agent-hooks-darwin-x64/-/agent-hooks-darwin-x64-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-+L+G1sbZN8HyPbyzL6uJ6YG7utqrmRfoD2Oa8PbDHKaGSPKEvSqY5MNyT4lpmMU12i6sLTsGEwEllGiYdTm0Gg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=20"
-      }
+      "optional": true
     },
     "node_modules/@responsibleai/agent-hooks-linux-x64-gnu": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@responsibleai/agent-hooks-linux-x64-gnu/-/agent-hooks-linux-x64-gnu-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-7pSqVjTfsOuhCA3tVtgUD6/VG4RuXN86QOA4J+LYnGHHYL0jIbIvviNrCyeId3JPWijyThLLgQLAGCJeXiRTxA==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=20"
-      }
+      "optional": true
     },
     "node_modules/@responsibleai/agent-hooks-win32-x64-msvc": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@responsibleai/agent-hooks-win32-x64-msvc/-/agent-hooks-win32-x64-msvc-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-bE9THeVW0JOJN7Gny+69awVyPvri1wljQqy2d9nwfuuka8V5NwmBp6DF/wxrFSBDxhBDboE4wEzgyuwjNS/uGA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=20"
-      }
+      "optional": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responsibleai/agent-hooks",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Framework-neutral agent control contract (AGENT-HOOKS-0.1). TypeScript wrapper over the canonical Rust core. Cooperative contract, not a security boundary: the host is fully trusted (see SECURITY.md).",
   "license": "MIT",
   "main": "./dist/index.js",
@@ -43,9 +43,9 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@responsibleai/agent-hooks-linux-x64-gnu": "0.1.0-alpha.2",
-    "@responsibleai/agent-hooks-darwin-x64": "0.1.0-alpha.2",
-    "@responsibleai/agent-hooks-darwin-arm64": "0.1.0-alpha.2",
-    "@responsibleai/agent-hooks-win32-x64-msvc": "0.1.0-alpha.2"
+    "@responsibleai/agent-hooks-linux-x64-gnu": "0.1.0-alpha.3",
+    "@responsibleai/agent-hooks-darwin-x64": "0.1.0-alpha.3",
+    "@responsibleai/agent-hooks-darwin-arm64": "0.1.0-alpha.3",
+    "@responsibleai/agent-hooks-win32-x64-msvc": "0.1.0-alpha.3"
   }
 }


### PR DESCRIPTION
Changes driven by the first external consumer of the contract (a policy decision runtime implementing the interceptor side):

- **Out-of-crate CTK harnesses** — `agent_hooks::ctk` re-exports `RunRecord`, `VectorResult`, `IdentityPair`, and `async_trait`, so third-party Rust hosts can implement the `Harness` trait and run the corpus under their own adapter name. A compile-and-run test pins the seam.
- **`InterceptionPoint` ordering and display** — derives `Ord`/`PartialOrd` (declaration order = the §3 lifecycle order, documented on the enum) and implements `Display` (wire name). The other SDKs already expose wire-string point types and needed no change.
- **Decision-runtime docs** — engine-internal failures surface as fail-closed denies under the engine's own reason namespace (`runtime_error:*` by convention), never the host-reserved `host_error:*` (§11); crate docs and README.

Versions bumped to `0.1.0-alpha.3` on every surface (consistency check passes); all three Cargo.locks and the npm lock resynced; changelog updated. Local matrix: Rust 116 tests + clippy + fmt clean; Python 179 passed (fresh alpha.3 build); TypeScript 126; .NET 117; Go untouched.