### PR TITLE
pack: bundle the FFI native library for four runtime identifiers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,7 +247,36 @@ jobs:
           done
         working-directory: sdk/typescript
 
+  ffi-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest,  target: x86_64-unknown-linux-gnu, rid: linux-x64, lib: libagent_hooks_ffi.so }
+          - { os: macos-latest,   target: aarch64-apple-darwin,     rid: osx-arm64, lib: libagent_hooks_ffi.dylib }
+          - { os: macos-latest,   target: x86_64-apple-darwin,      rid: osx-x64,   lib: libagent_hooks_ffi.dylib }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc,   rid: win-x64,   lib: agent_hooks_ffi.dll }
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master; toolchain pinned via sdk/rust/rust-toolchain.toml
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+      - name: Build FFI cdylib for ${{ matrix.target }}
+        shell: bash
+        run: cargo build --locked --release -p agent-hooks-ffi --target ${{ matrix.target }}
+        working-directory: sdk/rust
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ffi-${{ matrix.rid }}
+          path: sdk/rust/target/${{ matrix.target }}/release/${{ matrix.lib }}
+          if-no-files-found: error
+
   dotnet:
+    needs: ffi-build
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -256,13 +285,31 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master; toolchain pinned via sdk/rust/rust-toolchain.toml
-        with: { toolchain: stable }
-      - run: cargo build --locked -p agent-hooks-ffi --release
-        working-directory: sdk/rust
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: ffi-*
+          path: sdk/dotnet/ffi-artifacts
+      - name: Stage native runtimes into the pack layout
+        shell: bash
+        run: |
+          for rid in linux-x64 osx-x64 osx-arm64 win-x64; do
+            mkdir -p "src/AgentHooks/runtimes/$rid/native"
+            cp ffi-artifacts/ffi-"$rid"/* "src/AgentHooks/runtimes/$rid/native/"
+          done
+          find src/AgentHooks/runtimes -type f | sort
+          test "$(find src/AgentHooks/runtimes -type f | wc -l)" -eq 4
+        working-directory: sdk/dotnet
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with: { dotnet-version: "8.0.x" }
       - run: dotnet restore --locked-mode && dotnet pack src/AgentHooks -c Release -o dist
+        working-directory: sdk/dotnet
+      - name: Assert the nupkg bundles all four native runtimes
+        shell: bash
+        run: |
+          pkg=$(ls dist/*.nupkg)
+          for rid in linux-x64 osx-x64 osx-arm64 win-x64; do
+            unzip -l "$pkg" | grep -q "runtimes/$rid/native/" || { echo "::error::$rid native library missing from $pkg"; exit 1; }
+          done
         working-directory: sdk/dotnet
       - name: SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0

--- a/.gitignore
+++ b/.gitignore
@@ -461,3 +461,7 @@ sdk/go/**/*.test
 .DS_Store
 .claude/
 docs-site/docs/spec.md
+
+# Native pack staging (release pipeline / local pack verification)
+sdk/dotnet/src/AgentHooks/runtimes/
+sdk/dotnet/ffi-artifacts/

--- a/docs-site/docs/quickstart/dotnet.md
+++ b/docs-site/docs/quickstart/dotnet.md
@@ -4,18 +4,17 @@
 dotnet add package ResponsibleAI.AgentHooks --prerelease
 ```
 
-The NuGet package currently ships managed code only; the native core
-library (`libagent_hooks_ffi`) is loaded at run time and must be built
-once from the repository:
+The package bundles the native core library (`libagent_hooks_ffi`)
+for linux-x64, osx-x64, osx-arm64, and win-x64 under the standard
+`runtimes/` layout, so restore is the only step. Versions up to
+0.1.0-alpha.3 shipped managed code only; on those, build the native
+library from source and make it resolvable:
 
 ```sh
 git clone https://github.com/responsibleai/agent-hooks
 cargo build --release -p agent-hooks-ffi --manifest-path agent-hooks/sdk/rust/Cargo.toml
 export LD_LIBRARY_PATH=$PWD/agent-hooks/sdk/rust/target/release   # PATH on Windows
 ```
-
-Runtime-identifier packaging of the native library is planned; until
-then this is the one extra step.
 
 A minimal host with one control interceptor:
 

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -15,7 +15,7 @@ composition profiles, the identity-provider seam, and the CTK runner.
 > before relying on it.
 
 ```bash
-# Not yet published to NuGet — build from source (needs a Rust toolchain):
+# Or build from source (needs a Rust toolchain):
 git clone https://github.com/responsibleai/agent-hooks && cd agent-hooks
 cargo build --release --manifest-path sdk/rust/Cargo.toml -p agent-hooks-ffi
 dotnet build sdk/dotnet
@@ -44,8 +44,11 @@ shortcuts. Run the conformance tests with
 
 ## Native library deployment
 
-`ResponsibleAI.AgentHooks` P/Invokes `libagent_hooks_ffi`; the current
-NuGet package does **not** bundle it. Build it once per target platform
+`ResponsibleAI.AgentHooks` P/Invokes `libagent_hooks_ffi`. The NuGet
+package bundles it for linux-x64, osx-x64, osx-arm64, and win-x64 under
+`runtimes/<rid>/native/`, so package consumers need no extra step
+(versions up to 0.1.0-alpha.3 shipped managed code only). For source
+builds or other platforms, build it per target
 (`cargo build --release -p agent-hooks-ffi` under `sdk/rust`) and make
 it resolvable at process start:
 

--- a/sdk/dotnet/src/AgentHooks/AgentHooks.csproj
+++ b/sdk/dotnet/src/AgentHooks/AgentHooks.csproj
@@ -6,11 +6,12 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Native library resolved at runtime via NativeLibrary search paths.
-         Packaging: the current NuGet package does NOT bundle
-         libagent_hooks_ffi; consumers make it resolvable per OS (see
-         README "Native library deployment"). Per-RID bundling under
-         runtimes/<rid>/native/ is planned. For local dev, set
-         LD_LIBRARY_PATH / DYLD_LIBRARY_PATH / PATH to sdk/rust/target/release. -->
+    <!-- Per-RID native libraries (libagent_hooks_ffi) are staged under
+         runtimes/ by the release pipeline before pack, so the published
+         package resolves the native library through the standard RID
+         probing with no consumer action. The glob is empty in local dev
+         builds: resolve via LD_LIBRARY_PATH / DYLD_LIBRARY_PATH / PATH
+         to sdk/rust/target/release. -->
+    <None Include="runtimes/**" Pack="true" PackagePath="runtimes/" Visible="false" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The published `ResponsibleAI.AgentHooks` package ships managed code only, so every consumer must build `libagent_hooks_ffi` from source — proven blocking for downstream CI integration.

- `release.yml` gains an `ffi-build` matrix (same four targets and runners as the napi matrix) producing the cdylib per platform; the `dotnet` job stages the artifacts under `runtimes/<rid>/native/`, packs, and asserts all four runtimes are present in the nupkg before any publish step.
- `AgentHooks.csproj` packs the staged `runtimes/` tree (glob is empty for local dev builds, which keep resolving via the loader path variables).
- README and quickstart drop the build-from-source step for package consumers, retaining it for source builds and for versions up to 0.1.0-alpha.3.

Verified locally: linux-x64 staged pack contains `runtimes/linux-x64/native/libagent_hooks_ffi.so`; 118 tests green; `dotnet format` and actionlint clean. Takes effect with the next published version.