### PR TITLE
ci: install cross targets for the pinned toolchain in ffi-build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,6 +265,13 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
+      - name: Install ${{ matrix.target }} for the pinned toolchain
+        # rust-toolchain.toml pins the toolchain inside sdk/rust; the
+        # setup action installs targets for `stable` only, so cross
+        # targets must be added in the pinned context.
+        shell: bash
+        run: rustup target add ${{ matrix.target }}
+        working-directory: sdk/rust
       - name: Build FFI cdylib for ${{ matrix.target }}
         shell: bash
         run: cargo build --locked --release -p agent-hooks-ffi --target ${{ matrix.target }}


### PR DESCRIPTION
The nupkg native-runtimes dry-run failed on the osx-x64 leg with E0463: the toolchain setup action installs targets for `stable`, while the build runs inside `sdk/rust` where `rust-toolchain.toml` pins the toolchain — the pinned toolchain never received the cross target. Host-native legs were unaffected. `rustup target add` executed inside the pinned directory scope installs for the active toolchain.