### PR TITLE
release: bump every SDK surface to 0.1.0-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 User-visible changes to the spec and SDKs. Versioning rules:
 [VERSIONING.md](VERSIONING.md).
 
+## 0.1.0-alpha.4 — tag `v0.1.0-alpha.4`
+
+- **.NET: the NuGet package ships the native library.** The nupkg now
+  bundles the FFI cdylib for four runtime identifiers
+  (`runtimes/{linux-x64,osx-x64,osx-arm64,win-x64}/native/`), so
+  package consumers no longer build `agent_hooks_ffi` from source. The
+  release pipeline cross-builds all four targets and asserts their
+  presence in the packed package.
+- **`deny` constructor sugar in every SDK.** A plain, final deny
+  (reason + optional message, no `approval` block) alongside the
+  existing `warn`/`escalate` sugar: Rust `Verdict::deny`, Python
+  `Verdict.deny`, TypeScript `Verdict.deny`, .NET `Verdict.Deny`, and
+  Go `DenyVerdict` (suffixed like `AllowVerdict` because `Deny` is the
+  `Decision` constant). (Merged after the alpha.3 tag; previously
+  listed under alpha.3 in error.)
+- **Go: `Interceptor.OnHook` renamed to `Intercept`,** aligning the
+  interceptor protocol method with Python/TypeScript `intercept` and
+  .NET `InterceptAsync`. Clean rename, no alias (pre-release; drafts
+  within the 0.1 window are not compatibility-bound). (Merged after
+  the alpha.3 tag; previously listed under alpha.3 in error.)
+- Registry publishing is trusted-publishing-only on every registry;
+  the one-time bootstrap token paths are removed from the release
+  workflow.
+
 ## 0.1.0-alpha.3
 
 Additive; driven by the first external consumer of the contract (a
@@ -17,16 +41,6 @@ policy decision runtime implementing the interceptor side).
   order = the §3 lifecycle order, documented on the enum) **and
   implements `Display`** (wire name). The other SDKs already expose
   wire-string point types and needed no change.
-- **`deny` constructor sugar in every SDK.** A plain, final deny
-  (reason + optional message, no `approval` block) alongside the
-  existing `warn`/`escalate` sugar: Rust `Verdict::deny`, Python
-  `Verdict.deny`, TypeScript `Verdict.deny`, .NET `Verdict.Deny`, and
-  Go `DenyVerdict` (suffixed like `AllowVerdict` because `Deny` is the
-  `Decision` constant).
-- **Go: `Interceptor.OnHook` renamed to `Intercept`,** aligning the
-  interceptor protocol method with Python/TypeScript `intercept` and
-  .NET `InterceptAsync`. Clean rename, no alias (pre-release; drafts
-  within the 0.1 window are not compatibility-bound).
 - **Docs: decision runtimes behind an interceptor.** Crate-level
   rustdoc and the README now state the reason-namespace convention:
   engine-internal failures surface as fail-closed denies under the

--- a/sdk/dotnet/Directory.Build.props
+++ b/sdk/dotnet/Directory.Build.props
@@ -8,7 +8,7 @@
     <Authors>Responsible AI</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/responsibleai/agent-hooks</RepositoryUrl>
-    <Version>0.1.0-alpha.3</Version>
+    <Version>0.1.0-alpha.4</Version>
     <!-- Supply chain: lock NuGet resolution; CI restores in locked mode. -->
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-hooks-python"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "agent-hooks-sdk",
  "pyo3",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "agent-hooks-sdk"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-hooks-python"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 edition = "2021"
 license = "MIT"
 description = "PyO3 bindings for the agent-hooks Rust core."

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 # similarity check blocks all separator variants (incl. agenthooks).
 # Import name stays agent_hooks.
 name = "agent-hooks-sdk"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "Framework-neutral agent control contract: interception points, agent context, verdict, and conformance test kit. Python wrapper over the canonical Rust core. Cooperative contract, not a security boundary: the host is fully trusted (see SECURITY.md)."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -4,14 +4,14 @@ version = 3
 
 [[package]]
 name = "agent-hooks-ffi"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "agent-hooks-sdk",
 ]
 
 [[package]]
 name = "agent-hooks-sdk"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "async-trait",
  "criterion",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["core", "ffi"]
 
 [workspace.package]
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/sdk/typescript/Cargo.lock
+++ b/sdk/typescript/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-hooks-node"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "agent-hooks-sdk",
  "napi",
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "agent-hooks-sdk"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/sdk/typescript/Cargo.toml
+++ b/sdk/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-hooks-node"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 edition = "2021"
 license = "MIT"
 description = "napi-rs bindings for the agent-hooks Rust core."

--- a/sdk/typescript/binding.js
+++ b/sdk/typescript/binding.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-android-arm64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-android-arm-eabi')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-win32-x64-gnu')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-win32-x64-msvc')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-win32-ia32-msvc')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-win32-arm64-msvc')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@responsibleai/agent-hooks-darwin-universal')
       const bindingPackageVersion = require('@responsibleai/agent-hooks-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-darwin-x64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-darwin-arm64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-freebsd-x64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-freebsd-arm64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-x64-musl')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-x64-gnu')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-arm64-musl')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-arm64-gnu')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-arm-musleabihf')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-loong64-musl')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-loong64-gnu')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-riscv64-musl')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-riscv64-gnu')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-linux-ppc64-gnu')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-linux-s390x-gnu')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-openharmony-arm64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-openharmony-x64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-openharmony-arm')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdk/typescript/npm/darwin-arm64/package.json
+++ b/sdk/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responsibleai/agent-hooks-darwin-arm64",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "cpu": [
     "arm64"
   ],

--- a/sdk/typescript/npm/darwin-x64/package.json
+++ b/sdk/typescript/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responsibleai/agent-hooks-darwin-x64",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "cpu": [
     "x64"
   ],

--- a/sdk/typescript/npm/linux-x64-gnu/package.json
+++ b/sdk/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responsibleai/agent-hooks-linux-x64-gnu",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "cpu": [
     "x64"
   ],

--- a/sdk/typescript/npm/win32-x64-msvc/package.json
+++ b/sdk/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responsibleai/agent-hooks-win32-x64-msvc",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "cpu": [
     "x64"
   ],

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@responsibleai/agent-hooks",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@responsibleai/agent-hooks",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-alpha.4",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^3.7.2",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responsibleai/agent-hooks",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "description": "Framework-neutral agent control contract (AGENT-HOOKS-0.1). TypeScript wrapper over the canonical Rust core. Cooperative contract, not a security boundary: the host is fully trusted (see SECURITY.md).",
   "license": "MIT",
   "main": "./dist/index.js",


### PR DESCRIPTION
Bumps all four version manifests, the platform package versions, the binding version check, and the locks to 0.1.0-alpha.4; consistency check passes. The changelog gains the alpha.4 section (nupkg native runtimes for four RIDs; deny constructor sugar; Go interceptor rename — the latter two moved out of the alpha.3 section where they were misfiled, having merged after that tag). Loader optionalDependencies pins remain at the published alpha.3; the release pipeline's `napi version` step syncs and asserts them at publish time. Local verification: rust 8 suites + clippy, python 180 passed + ruff, typescript 127 passed, dotnet 118 passed.