### PR TITLE
conformance: file the agent-control-spec claim

### DIFF
--- a/conformance/CLAIMS.md
+++ b/conformance/CLAIMS.md
@@ -28,6 +28,7 @@ retract already-streamed content (§12.1a).
 | Framework | Adapter version | Spec | Capabilities | Profiles | Identity provider | SDK | Report | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | reference-agent | 0.1.0 | agent-hooks/0.1 | model_calls, tool_calls, int64_json (not typescript) | all four (§7.2), all knobs | jcs-sha256 (+ null, vector-scoped) | python, typescript, dotnet, go, rust | (CI: CTK self-test, all parts) | In-tree reference |
+| [agent-control-spec](https://github.com/responsibleai/agent-control-spec) | 0.4.0-alpha.1 | agent-hooks/0.1 | model_calls, tool_calls, int64_json | all four (§7.2), all knobs | jcs-sha256 (+ null, vector-scoped) | rust@0.1.0-alpha.3 | [per-part report](https://github.com/responsibleai/agent-control-spec/blob/a075ff9602e9/conformance/agent-hooks/REPORT.md) — 46/47, 1 capability-gated skip (bigint_json undeclared) | Policy decision runtime; engine registered as the interceptor behind a first-party harness over the production emitter loop |
 
 ## Filing and acceptance
 


### PR DESCRIPTION
Files the first external conformance claim: agent-control-spec 0.4.0-alpha.1 against agent-hooks/0.1.

Per the filing requirements: (1) the per-part report is linked at a pinned commit — 46/47 passed, 0 failed, one capability-gated skip (`bigint_json` undeclared: serde_json coerces beyond-u64 vector literals at load, so the host cannot present such contexts faithfully; `int64_json` is declared and passes). (2) Harness: the repository's first-party `ctk::Harness` (`agent-control-spec-reference-host`, rust runner @0.1.0-alpha.3) drives the production agent-hooks emitter loop with the policy engine registered as the interceptor; only model/tool I/O is scripted by the corpus. (3) Disclosure flags: none applicable — identity provider is the content-derived `jcs-sha256` default (plus vector-scoped `null`), and `buffered_output: false` is not declared.