### PR TITLE
spec: schema $id URIs point at the documentation site, which now serves them

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,6 +26,12 @@ jobs:
           uv venv .mkdocs-venv
           uv pip install --python .mkdocs-venv/bin/python "mkdocs-material==9.6.23"
           cp spec/AGENT-HOOKS-0.1.md docs-site/docs/spec.md
+          # Publish the machine-readable schemas so every $id dereferences.
+          mkdir -p docs-site/docs/schema/v0.1/agent-context docs-site/docs/schema/v0.1/conformance
+          cp spec/schema/*.json docs-site/docs/schema/v0.1/
+          cp spec/schema/agent-context/*.json docs-site/docs/schema/v0.1/agent-context/
+          cp spec/reserved-reasons.json docs-site/docs/schema/v0.1/
+          cp conformance/vectors.schema.json docs-site/docs/schema/v0.1/conformance/
           .mkdocs-venv/bin/mkdocs build --strict -f docs-site/mkdocs.yml -d "$PWD/site"
       - name: Upload Pages artifact
         if: github.event_name == 'push'

--- a/.gitignore
+++ b/.gitignore
@@ -461,6 +461,7 @@ sdk/go/**/*.test
 .DS_Store
 .claude/
 docs-site/docs/spec.md
+docs-site/docs/schema/
 
 # Native pack staging (release pipeline / local pack verification)
 sdk/dotnet/src/AgentHooks/runtimes/

--- a/conformance/vectors.schema.json
+++ b/conformance/vectors.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/conformance/vectors.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/conformance/vectors.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks — CTK vector",
   "description": "Language-agnostic conformance test case (AGENT-HOOKS-0.1 §13.2). Scripts use the three-verdict vocabulary (§5): an escalation is a deny with an approval block; a warning is an allow with a warnings[] entry. Non-finite floats (NaN/Infinity) and lone surrogates cannot be expressed in a JSON vector file; those guards are pinned by per-SDK unit tests instead (§4.4).",
@@ -263,7 +263,7 @@
       ],
       "properties": {
         "at": {
-          "$ref": "https://agent-hooks.responsibleai.dev/v0.1/interception-point.schema.json"
+          "$ref": "https://responsibleai.github.io/agent-hooks/schema/v0.1/interception-point.schema.json"
         },
         "match": {
           "type": "object",
@@ -271,7 +271,7 @@
           "description": "Dotted-path -> expected-value predicates against the AgentContext. All must match."
         },
         "return": {
-          "$ref": "https://agent-hooks.responsibleai.dev/v0.1/verdict.schema.json"
+          "$ref": "https://responsibleai.github.io/agent-hooks/schema/v0.1/verdict.schema.json"
         },
         "fault": {
           "type": "string",
@@ -320,7 +320,7 @@
               ]
             },
             "verdict": {
-              "$ref": "https://agent-hooks.responsibleai.dev/v0.1/verdict.schema.json"
+              "$ref": "https://responsibleai.github.io/agent-hooks/schema/v0.1/verdict.schema.json"
             },
             "fault": {
               "type": "string",
@@ -370,7 +370,7 @@
             ],
             "properties": {
               "interception_point": {
-                "$ref": "https://agent-hooks.responsibleai.dev/v0.1/interception-point.schema.json"
+                "$ref": "https://responsibleai.github.io/agent-hooks/schema/v0.1/interception-point.schema.json"
               },
               "context": {
                 "type": "object",
@@ -391,7 +391,7 @@
         "interceptions_absent": {
           "type": "array",
           "items": {
-            "$ref": "https://agent-hooks.responsibleai.dev/v0.1/interception-point.schema.json"
+            "$ref": "https://responsibleai.github.io/agent-hooks/schema/v0.1/interception-point.schema.json"
           }
         },
         "tool_invocations": {
@@ -441,7 +441,7 @@
             ],
             "properties": {
               "interception_point": {
-                "$ref": "https://agent-hooks.responsibleai.dev/v0.1/interception-point.schema.json"
+                "$ref": "https://responsibleai.github.io/agent-hooks/schema/v0.1/interception-point.schema.json"
               },
               "assert": {
                 "type": "object",

--- a/scripts/gen-per-point-schemas.py
+++ b/scripts/gen-per-point-schemas.py
@@ -48,7 +48,7 @@ def main() -> None:
             if d in defs and defs[d].get("type") == "object":
                 defs[d]["additionalProperties"] = False
         schema = {
-            "$id": f"https://agent-hooks.responsibleai.dev/v0.1/agent-context/{hp}.schema.json",
+            "$id": f"https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/{hp}.schema.json",
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "title": f"Agent Hooks — agent context ({hp})",
             "description": (

--- a/sdk/python/python/agent_hooks/schema/agent-context.schema.json
+++ b/sdk/python/python/agent_hooks/schema/agent-context.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks — agent context",
   "description": "Payload a host constructs at each interception point (AGENT-HOOKS-0.1 §4). required fields are always present; conditional fields are required per interception_point; optional fields are well-known; namespaced extensions live under extensions.",

--- a/sdk/python/python/agent_hooks/schema/agent-context/agent_shutdown.schema.json
+++ b/sdk/python/python/agent_hooks/schema/agent-context/agent_shutdown.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/agent_shutdown.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/agent_shutdown.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (agent_shutdown)",
   "description": "Closed required+conditional schema for interception_point=agent_shutdown (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/sdk/python/python/agent_hooks/schema/agent-context/agent_startup.schema.json
+++ b/sdk/python/python/agent_hooks/schema/agent-context/agent_startup.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/agent_startup.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/agent_startup.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (agent_startup)",
   "description": "Closed required+conditional schema for interception_point=agent_startup (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/sdk/python/python/agent_hooks/schema/agent-context/input.schema.json
+++ b/sdk/python/python/agent_hooks/schema/agent-context/input.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/input.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/input.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (input)",
   "description": "Closed required+conditional schema for interception_point=input (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/sdk/python/python/agent_hooks/schema/agent-context/output.schema.json
+++ b/sdk/python/python/agent_hooks/schema/agent-context/output.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/output.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/output.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (output)",
   "description": "Closed required+conditional schema for interception_point=output (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/sdk/python/python/agent_hooks/schema/agent-context/post_model_call.schema.json
+++ b/sdk/python/python/agent_hooks/schema/agent-context/post_model_call.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/post_model_call.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/post_model_call.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (post_model_call)",
   "description": "Closed required+conditional schema for interception_point=post_model_call (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/sdk/python/python/agent_hooks/schema/agent-context/post_tool_call.schema.json
+++ b/sdk/python/python/agent_hooks/schema/agent-context/post_tool_call.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/post_tool_call.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/post_tool_call.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (post_tool_call)",
   "description": "Closed required+conditional schema for interception_point=post_tool_call (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/sdk/python/python/agent_hooks/schema/agent-context/pre_model_call.schema.json
+++ b/sdk/python/python/agent_hooks/schema/agent-context/pre_model_call.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/pre_model_call.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/pre_model_call.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (pre_model_call)",
   "description": "Closed required+conditional schema for interception_point=pre_model_call (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/sdk/python/python/agent_hooks/schema/agent-context/pre_tool_call.schema.json
+++ b/sdk/python/python/agent_hooks/schema/agent-context/pre_tool_call.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/pre_tool_call.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/pre_tool_call.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (pre_tool_call)",
   "description": "Closed required+conditional schema for interception_point=pre_tool_call (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/sdk/python/python/agent_hooks/schema/approval.schema.json
+++ b/sdk/python/python/agent_hooks/schema/approval.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/approval.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/approval.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks — approval seam",
   "description": "Approval request and resolution shapes for lifting a liftable deny (AGENT-HOOKS-0.1 §9). context_identity is an opaque provider-produced string, or null when identity_provider is null (§10.1); the only normative constraint is the echo rule.",

--- a/sdk/python/python/agent_hooks/schema/interception-point.schema.json
+++ b/sdk/python/python/agent_hooks/schema/interception-point.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/interception-point.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/interception-point.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks — interception point",
   "description": "The closed set of agent lifecycle interception points (AGENT-HOOKS-0.1 §3).",

--- a/sdk/python/python/agent_hooks/schema/interception-record.schema.json
+++ b/sdk/python/python/agent_hooks/schema/interception-record.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/interception-record.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/interception-record.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks — interception record",
   "description": "Host-side record of one emission (AGENT-HOOKS-0.1 §10.3). Payload-free: identities (when a provider is declared) bind the record to the exact pre/post-composition context; session_id/sequence/decided_by provide ordering and attribution; composition makes the record interpretable without out-of-band host configuration.",

--- a/sdk/python/python/agent_hooks/schema/verdict.schema.json
+++ b/sdk/python/python/agent_hooks/schema/verdict.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/verdict.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/verdict.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks — verdict",
   "description": "Interceptor return value (AGENT-HOOKS-0.1 §5). Three decisions: allow (absorbs warn via warnings[]), deny (absorbs escalate via the approval block), transform. A verdict carries decision content only; composition is host configuration (§7.1).",

--- a/spec/reserved-reasons.json
+++ b/spec/reserved-reasons.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/reserved-reasons.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/reserved-reasons.json",
   "title": "Agent Hooks — reserved host_error:* reasons",
   "description": "Host-synthesized deny reasons (AGENT-HOOKS-0.1 §11). Interceptors MUST NOT emit reasons with the host_error: prefix.",
   "reasons": [

--- a/spec/schema/agent-context.schema.json
+++ b/spec/schema/agent-context.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks — agent context",
   "description": "Payload a host constructs at each interception point (AGENT-HOOKS-0.1 §4). required fields are always present; conditional fields are required per interception_point; optional fields are well-known; namespaced extensions live under extensions.",

--- a/spec/schema/agent-context/agent_shutdown.schema.json
+++ b/spec/schema/agent-context/agent_shutdown.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/agent_shutdown.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/agent_shutdown.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (agent_shutdown)",
   "description": "Closed required+conditional schema for interception_point=agent_shutdown (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/spec/schema/agent-context/agent_startup.schema.json
+++ b/spec/schema/agent-context/agent_startup.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/agent_startup.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/agent_startup.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (agent_startup)",
   "description": "Closed required+conditional schema for interception_point=agent_startup (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/spec/schema/agent-context/input.schema.json
+++ b/spec/schema/agent-context/input.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/input.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/input.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (input)",
   "description": "Closed required+conditional schema for interception_point=input (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/spec/schema/agent-context/output.schema.json
+++ b/spec/schema/agent-context/output.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/output.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/output.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (output)",
   "description": "Closed required+conditional schema for interception_point=output (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/spec/schema/agent-context/post_model_call.schema.json
+++ b/spec/schema/agent-context/post_model_call.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/post_model_call.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/post_model_call.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (post_model_call)",
   "description": "Closed required+conditional schema for interception_point=post_model_call (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/spec/schema/agent-context/post_tool_call.schema.json
+++ b/spec/schema/agent-context/post_tool_call.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/post_tool_call.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/post_tool_call.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (post_tool_call)",
   "description": "Closed required+conditional schema for interception_point=post_tool_call (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/spec/schema/agent-context/pre_model_call.schema.json
+++ b/spec/schema/agent-context/pre_model_call.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/pre_model_call.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/pre_model_call.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (pre_model_call)",
   "description": "Closed required+conditional schema for interception_point=pre_model_call (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/spec/schema/agent-context/pre_tool_call.schema.json
+++ b/spec/schema/agent-context/pre_tool_call.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/agent-context/pre_tool_call.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/agent-context/pre_tool_call.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks \u2014 agent context (pre_tool_call)",
   "description": "Closed required+conditional schema for interception_point=pre_tool_call (AGENT-HOOKS-0.1 \u00a74.2). Used by the CTK for strict validation.",

--- a/spec/schema/approval.schema.json
+++ b/spec/schema/approval.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/approval.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/approval.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks — approval seam",
   "description": "Approval request and resolution shapes for lifting a liftable deny (AGENT-HOOKS-0.1 §9). context_identity is an opaque provider-produced string, or null when identity_provider is null (§10.1); the only normative constraint is the echo rule.",

--- a/spec/schema/interception-point.schema.json
+++ b/spec/schema/interception-point.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/interception-point.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/interception-point.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks — interception point",
   "description": "The closed set of agent lifecycle interception points (AGENT-HOOKS-0.1 §3).",

--- a/spec/schema/interception-record.schema.json
+++ b/spec/schema/interception-record.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/interception-record.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/interception-record.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks — interception record",
   "description": "Host-side record of one emission (AGENT-HOOKS-0.1 §10.3). Payload-free: identities (when a provider is declared) bind the record to the exact pre/post-composition context; session_id/sequence/decided_by provide ordering and attribution; composition makes the record interpretable without out-of-band host configuration.",

--- a/spec/schema/verdict.schema.json
+++ b/spec/schema/verdict.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://agent-hooks.responsibleai.dev/v0.1/verdict.schema.json",
+  "$id": "https://responsibleai.github.io/agent-hooks/schema/v0.1/verdict.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Agent Hooks — verdict",
   "description": "Interceptor return value (AGENT-HOOKS-0.1 §5). Three decisions: allow (absorbs warn via warnings[]), deny (absorbs escalate via the approval block), transform. A verdict carries decision content only; composition is host configuration (§7.1).",


### PR DESCRIPTION
The schema `$id` host referenced a custom domain that is no longer attached to the site. Every `$id` and absolute `$ref` now uses `https://responsibleai.github.io/agent-hooks/schema/v0.1/...`, and the Pages build publishes `spec/schema/`, `spec/reserved-reasons.json`, and `conformance/vectors.schema.json` at those exact paths, so each URI dereferences to its schema document. The per-point generator is updated as the source of truth and the vendored copies are regenerated (drift-clean). Verified: ajv compile across all schemas, 47/47 vectors valid, mkdocs strict build with the schemas present in the site output, Rust and Python suites green.