### PR TITLE
ci(python): publish wheels for supported platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,71 @@ env:
   DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
 
 jobs:
+  python-wheels:
+    name: Python wheel (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, platform: linux-x86_64 }
+          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, platform: linux-aarch64 }
+          - { os: macos-latest, target: x86_64-apple-darwin, platform: macos-x86_64 }
+          - { os: macos-latest, target: aarch64-apple-darwin, platform: macos-aarch64 }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc, platform: windows-x86_64 }
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up QEMU for Linux ARM64
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
+      - name: Build Linux wheel
+        if: runner.os == 'Linux'
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          target: ${{ matrix.target }}
+          args: --release --locked --compatibility pypi -m sdk/python/Cargo.toml -o dist
+          manylinux: "2_28"
+          maturin-version: v1.14.1
+          rust-toolchain: "1.95.0"
+      - name: Build macOS or Windows wheel
+        if: runner.os != 'Linux'
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          target: ${{ matrix.target }}
+          args: --release --locked --compatibility pypi -m sdk/python/Cargo.toml -o dist
+          maturin-version: v1.14.1
+          rust-toolchain: "1.95.0"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-wheel-${{ matrix.platform }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  python-sdist:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Build source distribution
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          command: sdist
+          args: -m sdk/python/Cargo.toml -o dist
+          maturin-version: v1.14.1
+          rust-toolchain: "1.95.0"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
   python:
+    needs: [python-wheels, python-sdist]
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -56,14 +120,26 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master; toolchain pinned via sdk/rust/rust-toolchain.toml
-        with: { toolchain: stable }
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-      - name: Build wheel + sdist
+      - uses: actions/download-artifact@3e5f45b2cfb9172054f4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: python-*
+          path: dist
+          merge-multiple: true
+      - name: Verify complete Python distribution
+        shell: bash
         run: |
-          uv tool install maturin==1.11.5
-          maturin build --release --locked -m sdk/python/Cargo.toml -o dist
-          maturin sdist -m sdk/python/Cargo.toml -o dist
+          test "$(find dist -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 5
+          test "$(find dist -maxdepth 1 -type f -name '*.tar.gz' | wc -l)" -eq 1
+          patterns=(
+            'dist/*manylinux*_x86_64.whl'
+            'dist/*manylinux*_aarch64.whl'
+            'dist/*macosx*_x86_64.whl'
+            'dist/*macosx*_arm64.whl'
+            'dist/*win_amd64.whl'
+          )
+          for pattern in "${patterns[@]}"; do
+            compgen -G "$pattern" >/dev/null || { echo "::error::missing artifact matching $pattern"; exit 1; }
+          done
       - name: SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:


### PR DESCRIPTION
Build ABI3 wheels for Linux x86_64 and ARM64, macOS Intel and Apple Silicon, and Windows x86_64. Aggregate the platform wheels with one source distribution before attestation and PyPI publication.