### PR TITLE
ci: CodeQL advanced setup so fork pull requests can satisfy the gate

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,10 +40,9 @@ jobs:
           - { language: rust,                  build-mode: none }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
-        with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
+      - if: matrix.language == 'go'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with: { go-version: "1.22" }
       - if: matrix.language == 'go'
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with: { toolchain: stable }
@@ -51,9 +50,10 @@ jobs:
         name: Build ffi cdylib (cgo dependency)
         run: cargo build --locked -p agent-hooks-ffi --release
         working-directory: sdk/rust
-      - if: matrix.language == 'go'
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with: { go-version: "1.22" }
+      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
       - if: matrix.language == 'go'
         name: Manual build for the Go extractor
         # The Go modules live under sdk/go, not the repo root.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,19 +29,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language:
-          - actions
-          - csharp
-          - go
-          - javascript-typescript
-          - python
-          - rust
+        include:
+          - { language: actions,               build-mode: none }
+          - { language: csharp,                build-mode: none }
+          # Go does not support build-mode none; manual mirrors the ci
+          # go job (FFI cdylib first, then go build).
+          - { language: go,                    build-mode: manual }
+          - { language: javascript-typescript, build-mode: none }
+          - { language: python,                build-mode: none }
+          - { language: rust,                  build-mode: none }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
-          build-mode: none
+          build-mode: ${{ matrix.build-mode }}
+      - if: matrix.language == 'go'
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with: { toolchain: stable }
+      - if: matrix.language == 'go'
+        name: Build ffi cdylib (cgo dependency)
+        run: cargo build --locked -p agent-hooks-ffi --release
+        working-directory: sdk/rust
+      - if: matrix.language == 'go'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with: { go-version: "1.22" }
+      - if: matrix.language == 'go'
+        name: Manual build for the Go extractor
+        run: go build ./...
       - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,10 @@ jobs:
         with: { go-version: "1.22" }
       - if: matrix.language == 'go'
         name: Manual build for the Go extractor
-        run: go build ./...
+        # The Go modules live under sdk/go, not the repo root.
+        run: |
+          cd sdk/go/agenthooks && go build ./...
+          cd ../conformance && go build ./...
       - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+# CodeQL advanced setup. Replaces the default setup: default-setup check
+# runs are never created on fork pull requests, which deadlocks the
+# required "Analyze (*)" contexts for external contributors. This
+# workflow runs on every pull request (fork or branch), so its contexts
+# are always reportable and can be required.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "17 7 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - csharp
+          - go
+          - javascript-typescript
+          - python
+          - rust
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
CodeQL default setup never creates its check runs on fork pull requests, so the six required `Analyze (*)` contexts are unsatisfiable for any external contribution (live example: #57, approved and otherwise green, refused with "6 of 17 required status checks are expected"). This adds the advanced-setup workflow — six languages, build-mode none, pull_request + main + weekly triggers — whose `CodeQL (<language>)` contexts report on every head, fork or branch. Follow-up (repo settings, after this merges and proves green on main): swap the required contexts and disable default setup to avoid double analysis.