### PR TITLE
release: inject npm platform pins at publish time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,15 +209,19 @@ jobs:
           npm install -g npm@latest
           V=$(node -p "require('./package.json').version")
           case "$V" in *-*) T=alpha;; *) T=latest;; esac
-          # Platform-package versions and the loader's optionalDependencies
-          # pins must both equal the main version (npx napi version syncs
-          # the dirs; the pins are updated in the same commit as a bump).
+          # The committed loader manifest carries NO optionalDependencies:
+          # pinning platform packages that only exist after this run makes
+          # main unbuildable between a version-bump merge and its publish.
+          # npx napi version syncs the platform dirs; the block is injected
+          # here from the loader version, so it cannot mismatch.
           npx napi version
-          # shellcheck disable=SC2016 # ${n}@${v} are JS template literals, not shell
           node -e '
-            const p = require("./package.json");
-            for (const [n, v] of Object.entries(p.optionalDependencies))
-              if (v !== p.version) { console.error(`optionalDependencies pin ${n}@${v} != ${p.version}`); process.exit(1); }
+            const fs = require("fs");
+            const p = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            const targets = ["linux-x64-gnu","darwin-x64","darwin-arm64","win32-x64-msvc"];
+            p.optionalDependencies = Object.fromEntries(
+              targets.map(t => ["@responsibleai/agent-hooks-" + t, p.version]));
+            fs.writeFileSync("package.json", JSON.stringify(p, null, 2) + "\n");
           '
           for dir in npm/linux-x64-gnu npm/darwin-x64 npm/darwin-arm64 npm/win32-x64-msvc .; do
             name=$(node -p "require('./$dir/package.json').name")

--- a/scripts/check-version-consistency.py
+++ b/scripts/check-version-consistency.py
@@ -71,4 +71,18 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    check_no_committed_platform_pins()
     sys.exit(main())
+
+
+def check_no_committed_platform_pins():
+    """The loader manifest must not pin platform packages; the release
+    workflow injects optionalDependencies at publish time."""
+    import json as _json
+    with open("sdk/typescript/package.json", encoding="utf-8") as f:
+        pkg = _json.load(f)
+    if "optionalDependencies" in pkg:
+        raise SystemExit(
+            "sdk/typescript/package.json commits optionalDependencies; "
+            "platform pins are injected at publish time (see release.yml)"
+        )

--- a/scripts/check-version-consistency.py
+++ b/scripts/check-version-consistency.py
@@ -71,7 +71,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    check_no_committed_platform_pins()
     sys.exit(main())
 
 
@@ -79,6 +78,7 @@ def check_no_committed_platform_pins():
     """The loader manifest must not pin platform packages; the release
     workflow injects optionalDependencies at publish time."""
     import json as _json
+
     with open("sdk/typescript/package.json", encoding="utf-8") as f:
         pkg = _json.load(f)
     if "optionalDependencies" in pkg:
@@ -86,3 +86,7 @@ def check_no_committed_platform_pins():
             "sdk/typescript/package.json commits optionalDependencies; "
             "platform pins are injected at publish time (see release.yml)"
         )
+
+
+if __name__ == "__main__":
+    check_no_committed_platform_pins()

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -15,12 +15,6 @@
       },
       "engines": {
         "node": ">=20"
-      },
-      "optionalDependencies": {
-        "@responsibleai/agent-hooks-darwin-arm64": "0.1.0-alpha.3",
-        "@responsibleai/agent-hooks-darwin-x64": "0.1.0-alpha.3",
-        "@responsibleai/agent-hooks-linux-x64-gnu": "0.1.0-alpha.3",
-        "@responsibleai/agent-hooks-win32-x64-msvc": "0.1.0-alpha.3"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1608,73 +1602,6 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
-      }
-    },
-    "node_modules/@responsibleai/agent-hooks-darwin-arm64": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@responsibleai/agent-hooks-darwin-arm64/-/agent-hooks-darwin-arm64-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-SHgLRoffgakNDAYkmtPPH8anxvVh23CANWktaKP4yfhslgFn/UnrIOOrkWGSic12nnWGEUxz9RqsziETEbgiMg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@responsibleai/agent-hooks-darwin-x64": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@responsibleai/agent-hooks-darwin-x64/-/agent-hooks-darwin-x64-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-wTiC9WAsZ/h7D8uqbydVTHLKskennH0GkC5Wt+tmGrQdScb7u/Ip8Muj2FfiZqYgzDHZ+NO5cjqHy39Yk2suGA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@responsibleai/agent-hooks-linux-x64-gnu": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@responsibleai/agent-hooks-linux-x64-gnu/-/agent-hooks-linux-x64-gnu-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-uUKSNPdGERbrlSmJiVaOQVBiZUtbo/MXHYLEGu0KD3aJ3vwdx+uhQgdC/H/HY6TyBQuXG09EvuHQCJVT/vPpQw==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@responsibleai/agent-hooks-win32-x64-msvc": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@responsibleai/agent-hooks-win32-x64-msvc/-/agent-hooks-win32-x64-msvc-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-s5jwaLIITReYOnApxchdwt2ZyHBeYviJOocqmUqOAUn7mzqlAARKm+jCZxagQacwZcE9DZF3mRIBTnnWNYml/w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -41,11 +41,5 @@
   },
   "engines": {
     "node": ">=20"
-  },
-  "optionalDependencies": {
-    "@responsibleai/agent-hooks-linux-x64-gnu": "0.1.0-alpha.3",
-    "@responsibleai/agent-hooks-darwin-x64": "0.1.0-alpha.3",
-    "@responsibleai/agent-hooks-darwin-arm64": "0.1.0-alpha.3",
-    "@responsibleai/agent-hooks-win32-x64-msvc": "0.1.0-alpha.3"
   }
 }


### PR DESCRIPTION
The current release's npm leg failed its pin assertion: the version bump missed the loader's committed `optionalDependencies`. The deeper defect is the same-commit pin convention itself — it leaves main unable to `npm ci` between any bump merge and its publish, because the pinned platform packages do not exist yet. The loader manifest no longer commits the block; the publish step injects it from the loader version (cannot mismatch), and the version-consistency script rejects any future committed pins.