### PR TITLE
release: 0.1.0-alpha.5 — Python Verdict.allow(), linux-arm64-gnu napi target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,10 @@
 #            on the package (repo responsibleai/agent-hooks, workflow
 #            release.yml, environment release) at
 #            npmjs.com > package > Settings > Trusted Publisher.
-#            No token; all five packages (loader + four platform
-#            packages) have trusted publishers configured.
+#            No token; every package (the loader + each platform
+#            package) needs its own trusted publisher. A brand-new
+#            platform package cannot be configured before its first
+#            publish, so its leg fails soft (see the npm publish step).
 #   NuGet  — trusted publishing (OIDC): configure a Trusted Publishing
 #            policy on nuget.org (repo responsibleai/agent-hooks,
 #            workflow release.yml, environment release); the NuGet/login
@@ -211,10 +213,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-latest,  target: x86_64-unknown-linux-gnu }
-          - { os: macos-latest,   target: aarch64-apple-darwin }
-          - { os: macos-latest,   target: x86_64-apple-darwin }
-          - { os: windows-latest, target: x86_64-pc-windows-msvc }
+          - { os: ubuntu-latest,      target: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-24.04-arm,   target: aarch64-unknown-linux-gnu }
+          - { os: macos-latest,       target: aarch64-apple-darwin }
+          - { os: macos-latest,       target: x86_64-apple-darwin }
+          - { os: windows-latest,     target: x86_64-pc-windows-msvc }
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -278,7 +281,7 @@ jobs:
             sdk/typescript/npm/**/*.node
       - name: Publish to npm (platform packages, then the loader package)
         if: env.DRY_RUN != 'true'
-        # OIDC trusted publishing: no token. Each package (the four
+        # OIDC trusted publishing: no token. Each package (the
         # platform packages and the loader) has its own trusted
         # publisher on npmjs.com (repo responsibleai/agent-hooks,
         # workflow release.yml, environment release). The repo is
@@ -299,20 +302,29 @@ jobs:
           node -e '
             const fs = require("fs");
             const p = JSON.parse(fs.readFileSync("package.json", "utf8"));
-            const targets = ["linux-x64-gnu","darwin-x64","darwin-arm64","win32-x64-msvc"];
+            const targets = ["linux-x64-gnu","linux-arm64-gnu","darwin-x64","darwin-arm64","win32-x64-msvc"];
             p.optionalDependencies = Object.fromEntries(
               targets.map(t => ["@responsibleai/agent-hooks-" + t, p.version]));
             fs.writeFileSync("package.json", JSON.stringify(p, null, 2) + "\n");
           '
-          for dir in npm/linux-x64-gnu npm/darwin-x64 npm/darwin-arm64 npm/win32-x64-msvc .; do
+          for dir in npm/linux-x64-gnu npm/linux-arm64-gnu npm/darwin-x64 npm/darwin-arm64 npm/win32-x64-msvc .; do
             name=$(node -p "require('./$dir/package.json').name")
             if [ "$dir" != "." ] && ! ls "$dir"/*.node >/dev/null 2>&1; then
               echo "::error::$name has no native artifact"; exit 1
             fi
             if npm view "$name@$V" version >/dev/null 2>&1; then
               echo "$name@$V already on npm — skipping"
+            elif (cd "$dir" && npm publish --access public --tag "$T"); then
+              :
+            elif ! npm view "$name" name >/dev/null 2>&1; then
+              # npm trusted publishing cannot be configured for a package
+              # that has never been published, so a brand-new platform
+              # package fails its first OIDC publish. Fail soft: consumers
+              # tolerate a missing optionalDependency; bootstrap the
+              # package manually, then rerun this workflow (idempotent).
+              echo "::warning::$name@$V first publish failed — bootstrap the new package on npmjs.com (one-time token publish), configure its trusted publisher, then rerun"
             else
-              (cd "$dir" && npm publish --access public --tag "$T")
+              exit 1
             fi
           done
         working-directory: sdk/typescript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,21 @@
 User-visible changes to the spec and SDKs. Versioning rules:
 [VERSIONING.md](VERSIONING.md).
 
-## Unreleased
+## 0.1.0-alpha.5 — tag `v0.1.0-alpha.5`
 
+- **Python: `Verdict.allow()` constructor sugar,** completing the
+  cross-SDK vocabulary: Rust `Verdict::allow`, TypeScript
+  `Verdict.allow()`, .NET `Verdict.Allow` and Go `AllowVerdict`
+  already existed; Python exposed only the module-level `ALLOW`
+  constant. The Python README interceptor example now uses the sugar
+  throughout.
+- **npm: prebuilt `linux-arm64-gnu` binary.** The TypeScript loader
+  gains a fifth platform package
+  (`@responsibleai/agent-hooks-linux-arm64-gnu`,
+  `aarch64-unknown-linux-gnu`), built natively on the arm64 hosted
+  runner. musl (Alpine) targets remain unshipped — the pipeline
+  builds on native runners only, and `linux-x64-musl` does not ship
+  either; a musl pair can land together later.
 - **§12.1 admits incremental mediation.** Previously a host had to
   assemble the complete response before `post_model_call` with no
   exception, so a host mediating a stream incrementally (e.g. per ACS

--- a/docs-site/docs/quickstart/typescript.md
+++ b/docs-site/docs/quickstart/typescript.md
@@ -5,8 +5,8 @@ npm install @responsibleai/agent-hooks
 ```
 
 The package resolves a prebuilt native binary for your platform through
-`optionalDependencies` (linux-x64-gnu, darwin-x64, darwin-arm64,
-win32-x64-msvc today).
+`optionalDependencies` (linux-x64-gnu, linux-arm64-gnu, darwin-x64,
+darwin-arm64, win32-x64-msvc today).
 
 A minimal host with one control interceptor:
 

--- a/sdk/dotnet/Directory.Build.props
+++ b/sdk/dotnet/Directory.Build.props
@@ -8,7 +8,7 @@
     <Authors>Responsible AI</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/responsibleai/agent-hooks</RepositoryUrl>
-    <Version>0.1.0-alpha.4</Version>
+    <Version>0.1.0-alpha.5</Version>
     <!-- Supply chain: lock NuGet resolution; CI restores in locked mode. -->
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-hooks-python"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 dependencies = [
  "agent-hooks-sdk",
  "pyo3",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "agent-hooks-sdk"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-hooks-python"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 edition = "2021"
 license = "MIT"
 description = "PyO3 bindings for the agent-hooks Rust core."

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -40,18 +40,19 @@ result = invoke_tool(ctx["tool_call"]["args"])  # post-transform args
 ## Interceptor usage
 
 ```python
-from agent_hooks import AgentContext, Decision, Verdict
+from agent_hooks import AgentContext, Verdict
+
 
 class MyPolicy:
     def intercept(self, ctx: AgentContext) -> Verdict:
         if ctx["interception_point"] == "pre_tool_call" and ctx["tool_call"]["name"] == "rm":
-            return Verdict(decision=Decision.DENY, reason="dangerous")
-        return Verdict(decision=Decision.ALLOW)
+            return Verdict.deny(reason="dangerous")
+        return Verdict.allow()
 ```
 
-`Verdict.warn(...)` (allow + recorded warning) and `Verdict.escalate(...)`
-(liftable deny for the approval seam, §9) are the constructor shortcuts for
-the other two §5 shapes.
+`Verdict.allow()`, `Verdict.deny(...)`, `Verdict.warn(...)` (allow + recorded
+warning) and `Verdict.escalate(...)` (liftable deny for the approval seam, §9)
+are the constructor shortcuts for the §5 shapes.
 
 ## Running the CTK against your framework
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 # similarity check blocks all separator variants (incl. agenthooks).
 # Import name stays agent_hooks.
 name = "agent-hooks-sdk"
-version = "0.1.0a4"
+version = "0.1.0a5"
 description = "Framework-neutral agent control contract: interception points, agent context, verdict, and conformance test kit. Python wrapper over the canonical Rust core. Cooperative contract, not a security boundary: the host is fully trusted (see SECURITY.md)."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/python/python/agent_hooks/_types.py
+++ b/sdk/python/python/agent_hooks/_types.py
@@ -206,6 +206,11 @@ class Verdict:
         return self.decision is Decision.DENY and self.approval is not None
 
     @classmethod
+    def allow(cls) -> Verdict:
+        """The trivial permit verdict."""
+        return cls(decision=Decision.ALLOW)
+
+    @classmethod
     def warn(cls, *, reason: str | None = None, message: str | None = None) -> Verdict:
         """Constructor sugar for what earlier drafts called ``warn``: an
         ``allow`` carrying one warning (§5.1)."""

--- a/sdk/python/tests/test_types.py
+++ b/sdk/python/tests/test_types.py
@@ -46,6 +46,16 @@ class TestVerdict:
         assert v.is_liftable
         assert not Verdict(decision=Decision.DENY).is_liftable
 
+    def test_allow_sugar_is_trivial_permit(self) -> None:
+        from agent_hooks import ALLOW
+
+        v = Verdict.allow()
+        assert v.decision is Decision.ALLOW
+        assert v == ALLOW
+        assert v.warnings == ()
+        assert v.approval is None
+        assert not v.is_liftable
+
     def test_warn_sugar_is_allow_with_warning(self) -> None:
         v = Verdict.warn(reason="pii", message="found ssn")
         assert v.decision is Decision.ALLOW

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -4,14 +4,14 @@ version = 3
 
 [[package]]
 name = "agent-hooks-ffi"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 dependencies = [
  "agent-hooks-sdk",
 ]
 
 [[package]]
 name = "agent-hooks-sdk"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 dependencies = [
  "async-trait",
  "criterion",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["core", "ffi"]
 
 [workspace.package]
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/sdk/typescript/Cargo.lock
+++ b/sdk/typescript/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-hooks-node"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 dependencies = [
  "agent-hooks-sdk",
  "napi",
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "agent-hooks-sdk"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/sdk/typescript/Cargo.toml
+++ b/sdk/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-hooks-node"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 edition = "2021"
 license = "MIT"
 description = "napi-rs bindings for the agent-hooks Rust core."

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -48,10 +48,10 @@ rejected fail-closed by a pre-serialization scan.
 
 ## Native module deployment
 
-The npm package bundles the napi-rs native module (`*.node`) **for the
-platform it was built on** — the published alpha ships `linux-x64-gnu`
-only. On other platforms, install from source (needs a Rust toolchain):
-`npm run build` produces the module for your host platform. Per-platform
+The napi-rs native module (`*.node`) ships as per-platform
 `optionalDependencies` packages (the standard napi-rs multi-platform
-layout) are planned. A platform mismatch fails at `require` time with a
-module-load error naming the missing `.node` binary.
+layout): `linux-x64-gnu`, `linux-arm64-gnu`, `darwin-x64`,
+`darwin-arm64` and `win32-x64-msvc`. On other platforms, install from
+source (needs a Rust toolchain): `npm run build` produces the module
+for your host platform. A platform mismatch fails at `require` time
+with a module-load error naming the missing `.node` binary.

--- a/sdk/typescript/binding.js
+++ b/sdk/typescript/binding.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-android-arm64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-android-arm-eabi')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-win32-x64-gnu')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-win32-x64-msvc')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-win32-ia32-msvc')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-win32-arm64-msvc')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@responsibleai/agent-hooks-darwin-universal')
       const bindingPackageVersion = require('@responsibleai/agent-hooks-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-darwin-x64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-darwin-arm64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-freebsd-x64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-freebsd-arm64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-x64-musl')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-x64-gnu')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-arm64-musl')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-arm64-gnu')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-arm-musleabihf')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-loong64-musl')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-loong64-gnu')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-riscv64-musl')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@responsibleai/agent-hooks-linux-riscv64-gnu')
           const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-linux-ppc64-gnu')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-linux-s390x-gnu')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-openharmony-arm64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-openharmony-x64')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@responsibleai/agent-hooks-openharmony-arm')
         const bindingPackageVersion = require('@responsibleai/agent-hooks-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.1.0-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.0-alpha.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -648,8 +648,8 @@ if (!nativeBinding || forceWasi) {
       if (!candidateFailed) {
         if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           const bindingPackageVersion = require('@responsibleai/agent-hooks-wasm32-wasi/package.json').version
-          if (bindingPackageVersion !== '0.1.0-alpha.4') {
-            throw new Error(`WASI binding package version mismatch, expected 0.1.0-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.0-alpha.5') {
+            throw new Error(`WASI binding package version mismatch, expected 0.1.0-alpha.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
         }
         wasiBinding = require('@responsibleai/agent-hooks-wasm32-wasi')

--- a/sdk/typescript/npm/darwin-arm64/package.json
+++ b/sdk/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responsibleai/agent-hooks-darwin-arm64",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "cpu": [
     "arm64"
   ],

--- a/sdk/typescript/npm/darwin-x64/package.json
+++ b/sdk/typescript/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responsibleai/agent-hooks-darwin-x64",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "cpu": [
     "x64"
   ],

--- a/sdk/typescript/npm/linux-arm64-gnu/README.md
+++ b/sdk/typescript/npm/linux-arm64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@responsibleai/agent-hooks-linux-arm64-gnu`
+
+This is the **aarch64-unknown-linux-gnu** binary for `@responsibleai/agent-hooks`

--- a/sdk/typescript/npm/linux-arm64-gnu/package.json
+++ b/sdk/typescript/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@responsibleai/agent-hooks-linux-arm64-gnu",
+  "version": "0.1.0-alpha.5",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "agent-hooks.linux-arm64-gnu.node",
+  "files": [
+    "agent-hooks.linux-arm64-gnu.node"
+  ],
+  "description": "Prebuilt linux-arm64-gnu native binary for @responsibleai/agent-hooks.",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/responsibleai/agent-hooks.git",
+    "directory": "sdk/typescript"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "glibc"
+  ]
+}

--- a/sdk/typescript/npm/linux-x64-gnu/package.json
+++ b/sdk/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responsibleai/agent-hooks-linux-x64-gnu",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "cpu": [
     "x64"
   ],

--- a/sdk/typescript/npm/win32-x64-msvc/package.json
+++ b/sdk/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responsibleai/agent-hooks-win32-x64-msvc",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "cpu": [
     "x64"
   ],

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@responsibleai/agent-hooks",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@responsibleai/agent-hooks",
-      "version": "0.1.0-alpha.4",
+      "version": "0.1.0-alpha.5",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^3.7.2",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responsibleai/agent-hooks",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "Framework-neutral agent control contract (AGENT-HOOKS-0.1). TypeScript wrapper over the canonical Rust core. Cooperative contract, not a security boundary: the host is fully trusted (see SECURITY.md).",
   "license": "MIT",
   "main": "./dist/index.js",
@@ -23,6 +23,7 @@
     "binaryName": "agent-hooks",
     "targets": [
       "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu",
       "x86_64-apple-darwin",
       "aarch64-apple-darwin",
       "x86_64-pc-windows-msvc"


### PR DESCRIPTION
Prepares and versions the 0.1.0-alpha.5 release.

## What

- **Python `Verdict.allow()`** — no-argument trivial-permit constructor sugar, completing cross-SDK parity (Rust `Verdict::allow`, TS `Verdict.allow()`, .NET `Verdict.Allow`, Go `AllowVerdict`). Test added; Python README example switched to the sugar forms.
- **npm `linux-arm64-gnu` platform package** — `aarch64-unknown-linux-gnu` added to the napi target set, committed `npm/linux-arm64-gnu/` package dir (standard napi-rs layout; the generated loader already resolves it), native build on `ubuntu-24.04-arm` in the release matrix, publish-time `optionalDependencies` injection extended. The npm publish loop now fails soft when a **never-published** package cannot OIDC-publish (trusted publishers cannot be configured pre-first-publish); existing packages still hard-fail.
- **Version bump to 0.1.0-alpha.5** across all manifests, lockfiles and platform package dirs; CHANGELOG folds the Unreleased §12.1 items (#64) into the alpha.5 section.

musl targets deliberately not added: the pipeline builds on native runners only and `linux-x64-musl` does not ship either; a musl pair can land together later.

## Verification

- `scripts/check-version-consistency.py` — surfaces agree at 0.1.0-alpha.5
- `actionlint` (pinned v1.7.12, checksum-verified) — clean
- `ruff format --check` / `ruff check` at the CI-pinned 0.15.21 — clean
- `pytest sdk/python/tests -p no:agent_hooks_ctk` — 181 passed, 2 skipped
- `cargo test --locked --workspace --all-features` (sdk/rust) — green
- `npm ci && npx tsc` (sdk/typescript) — green

## Follow-up (release time)

First publish of `@responsibleai/agent-hooks-linux-arm64-gnu` will warn-and-skip until the package is bootstrapped on npmjs.com and its trusted publisher configured; the release workflow is idempotent and can be rerun after.