### PR TITLE
feat(conformance): declared tool-seam posture and shape-agnostic AH-CTK-100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ User-visible changes to the spec and SDKs. Versioning rules:
 
 ## Unreleased
 
+- **CTK: declared `tool_seam_host_error` posture (§13.1).** A harness declares `continue` (default) or `terminate`, and `expect.run_outcome_by_posture` resolves the 13 tool-seam `host_error:*` vectors to the single outcome that declared surface must produce — the §6.2 terminate clause is now claimable (#68).
+- **CTK: AH-CTK-100 asserts §6.1 substance, not transcript cosmetics.** New `context_must_contain`/`context_must_not_contain` interception assertions pin non-incorporation of the denied tool result and the deny surfacing to the model in some form, leaving message layout and payload shape to the host (#69).
 - **The §12.1 incremental exception is CTK-testable.** The vectors
   the alpha.5 entry below left as future work exist: a
   `streaming/incremental` part (`AH-CTK-110`–`AH-CTK-113`) exercises

--- a/conformance/CLAIMS.md
+++ b/conformance/CLAIMS.md
@@ -16,7 +16,11 @@ or baseline profiles — the claim attaches the CTK's **per-part report**
 (runner results grouped by each vector's `part` tag), which
 communicates *what was exercised*, not a tier name.
 
-A claim with `identity_provider: null` MUST state that its records and
+A claim with a non-default posture (§13.1) MUST state it (e.g.
+`tool_seam_host_error: terminate` — the host terminates the turn on a
+`host_error:*` deny at the tool seam, which §6.2 permits); the report's
+passing vectors attest that posture's outcomes, not the default's. A
+claim with `identity_provider: null` MUST state that its records and
 approvals are identity-unbound (§10.1). A claim with a host-defined
 provider MUST disclose whether the provider is **content-derived**
 (a pure function of the projected context, like `jcs-sha256`) or not —
@@ -49,7 +53,9 @@ artefacts, in the PR:
    wires the framework — specifically confirming it drives the
    framework's **production dispatch path** with only model/tool I/O
    mocked (a harness that re-implements dispatch attests nothing).
-3. **Disclosure flags** where applicable: `identity_provider: null` →
+3. **Disclosure flags** where applicable: a non-default posture
+   (`tool_seam_host_error: terminate`) → the claim states it;
+   `identity_provider: null` →
    the claim states records/approvals are identity-unbound;
    custom provider → content-derived or not; `buffered_output: false`
    → the claim states a deny at `output` cannot retract streamed

--- a/conformance/HARNESS.md
+++ b/conformance/HARNESS.md
@@ -125,6 +125,32 @@ Non-finite floats (NaN/Infinity) and lone surrogates cannot be
 expressed in a JSON vector at all — those §4.4 marshalling guards are
 pinned by per-SDK unit tests, not vectors.
 
+## Postures
+
+Where the spec permits two host behaviors, the harness **declares**
+which one its host implements and the runner selects the single
+expected outcome for that declared surface — a vector never accepts
+"either outcome", so a pass always attests one specific behavior.
+
+`tool_seam_host_error: continue | terminate` (default `continue`)
+declares what the host does with the run after a `host_error:*` deny
+at `pre_tool_call`/`post_tool_call` (§6.2): `continue` surfaces a tool
+error to the model and keeps the loop going; `terminate` means the
+host's own semantics terminate the turn — the posture §6.2's "unless
+the host's own semantics terminate the turn" clause permits. Vectors
+whose run ends in such a deny carry `expect.run_outcome_by_posture`,
+and the runner resolves it against this declaration (forwarded in the
+run-record wire as `postures.tool_seam_host_error`).
+
+Declare it per SDK convention: a `tool_seam_host_error` attribute
+(Python), `toolSeamHostError` (TypeScript), the optional
+`ToolSeamHostErrorDeclarer` interface (Go), the `ToolSeamHostError`
+property (default interface member, .NET), or the
+`tool_seam_host_error()` trait method (Rust). Omitting it declares
+`continue` — the posture every in-tree reference harness implements.
+The declaration belongs in the host's §13.3 claim alongside its
+capabilities.
+
 ## Incremental mediation
 
 Vectors in the `streaming/incremental` part carry a chunked mock

--- a/conformance/RUNNER.md
+++ b/conformance/RUNNER.md
@@ -41,7 +41,11 @@ for each vector file in conformance/vectors/*.json:
                        {outcome:rr.outcome, final_output:rr.final_output,
                         tool_invocations:rr.tool_invocations, error:rr.error,
                         identities:rr.identities,      # (input, enforced) per emission
-                        records:rr.records})           # wire-shaped §10.3 records
+                        records:rr.records,            # wire-shaped §10.3 records
+                        postures:{                     # harness *declarations* (§13.1),
+                          tool_seam_host_error:        # not observed behavior — they
+                            harness.tool_seam_host_error  # select run_outcome_by_posture
+                              ?? "continue"}})            # (HARNESS.md "Postures")
 ```
 
 ## The conformance report (§13.1)

--- a/conformance/vectors.schema.json
+++ b/conformance/vectors.schema.json
@@ -394,6 +394,20 @@
               "context_must_validate": {
                 "type": "boolean",
                 "default": true
+              },
+              "context_must_contain": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Substrings that MUST appear somewhere in the serialization of the recorded AgentContext — shape-agnostic: pins that content surfaced to this interception point in SOME form (e.g. a deny reason surfaced to the model per §6.2) without prescribing message layout or payload format. Needles should avoid characters JSON escapes (quotes, backslashes, control characters)."
+              },
+              "context_must_not_contain": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Substrings that MUST NOT appear anywhere in the serialization of the recorded AgentContext — pins non-incorporation (§6.1): a discarded result must not surface here in any form. Same needle caveat as context_must_contain."
               }
             }
           }
@@ -449,7 +463,50 @@
             "completed",
             "blocked",
             "error"
-          ]
+          ],
+          "description": "The run outcome for a host with the spec-default posture. When run_outcome_by_posture is present, this MUST equal its outcomes entry for the default posture value (the engine enforces the equality), so pre-posture runners resolve the same expectation for default-posture hosts."
+        },
+        "run_outcome_by_posture": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "posture",
+            "outcomes"
+          ],
+          "properties": {
+            "posture": {
+              "type": "string",
+              "enum": [
+                "tool_seam_host_error"
+              ],
+              "description": "The declared host posture (§13.1) that selects the expected outcome. tool_seam_host_error: what the host does with the run after a host_error:* deny at pre_tool_call/post_tool_call — \"continue\" (the §6.2 default: surface a tool error to the model and keep the loop going) or \"terminate\" (the host's own semantics terminate the turn, which §6.2 explicitly permits)."
+            },
+            "outcomes": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "continue",
+                "terminate"
+              ],
+              "properties": {
+                "continue": {
+                  "enum": [
+                    "completed",
+                    "blocked",
+                    "error"
+                  ]
+                },
+                "terminate": {
+                  "enum": [
+                    "completed",
+                    "blocked",
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "description": "Posture-conditional run outcome, for behavior the spec permits either way (§6.2). The runner forwards the harness's declared posture and the engine selects the single outcome that declared surface must produce — each (vector, declared surface) pair stays single-valued, so a pass never means \"one of several outcomes happened\"."
         },
         "identities_equal": {
           "type": "boolean",

--- a/conformance/vectors/AH-CTK-070-interceptor-raises.json
+++ b/conformance/vectors/AH-CTK-070-interceptor-raises.json
@@ -21,6 +21,10 @@
     ],
     "interceptions_absent": ["post_tool_call"],
     "tool_not_invoked": ["http_get"],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/conformance/vectors/AH-CTK-071-malformed-verdict.json
+++ b/conformance/vectors/AH-CTK-071-malformed-verdict.json
@@ -21,6 +21,10 @@
     ],
     "interceptions_absent": ["post_tool_call"],
     "tool_not_invoked": ["http_get"],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/conformance/vectors/AH-CTK-072-resolver-identity-mismatch.json
+++ b/conformance/vectors/AH-CTK-072-resolver-identity-mismatch.json
@@ -91,6 +91,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/conformance/vectors/AH-CTK-073-resolver-raises.json
+++ b/conformance/vectors/AH-CTK-073-resolver-raises.json
@@ -86,6 +86,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/conformance/vectors/AH-CTK-085-parallel-transform-conflict-deny.json
+++ b/conformance/vectors/AH-CTK-085-parallel-transform-conflict-deny.json
@@ -96,6 +96,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/conformance/vectors/AH-CTK-087-unanimous-disagreement-deny.json
+++ b/conformance/vectors/AH-CTK-087-unanimous-disagreement-deny.json
@@ -93,6 +93,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/conformance/vectors/AH-CTK-092-evidence-cap.json
+++ b/conformance/vectors/AH-CTK-092-evidence-cap.json
@@ -80,6 +80,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/conformance/vectors/AH-CTK-094-failure-deny-attribution.json
+++ b/conformance/vectors/AH-CTK-094-failure-deny-attribution.json
@@ -86,6 +86,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/conformance/vectors/AH-CTK-095-postfold-domain-rejection.json
+++ b/conformance/vectors/AH-CTK-095-postfold-domain-rejection.json
@@ -85,6 +85,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/conformance/vectors/AH-CTK-097-runall-failure-slot.json
+++ b/conformance/vectors/AH-CTK-097-runall-failure-slot.json
@@ -72,7 +72,11 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   },
   "composition": {
     "profile": "sequential/run_all"

--- a/conformance/vectors/AH-CTK-098-approve-carrying-deny.json
+++ b/conformance/vectors/AH-CTK-098-approve-carrying-deny.json
@@ -91,6 +91,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/conformance/vectors/AH-CTK-100-deny-post-tool-non-incorporation.json
+++ b/conformance/vectors/AH-CTK-100-deny-post-tool-non-incorporation.json
@@ -1,6 +1,6 @@
 {
   "id": "AH-CTK-100",
-  "title": "deny at post_tool_call: the tool result is discarded, not incorporated into agent state (§6.1)",
+  "title": "deny at post_tool_call: the tool result is discarded, not incorporated into agent state; the deny surfaces to the model in some form, transcript shape unprescribed (§6.1)",
   "spec_clause": "6.1, 6.2",
   "part": "enforcement/post_action_deny",
   "capabilities": [
@@ -67,9 +67,15 @@
       },
       {
         "interception_point": "pre_model_call",
-        "context": {
-          "messages[1].role": "tool",
-          "messages[1].content": "blocked: ctk:tainted-result"
+        "context_must_contain": ["ctk:tainted-result"],
+        "context_must_not_contain": ["SECRET-RESULT"]
+      }
+    ],
+    "tool_invocations": [
+      {
+        "name": "http_get",
+        "args": {
+          "url": "https://x"
         }
       }
     ],

--- a/conformance/vectors/AH-CTK-102-runall-failed-transform-shortcircuit.json
+++ b/conformance/vectors/AH-CTK-102-runall-failed-transform-shortcircuit.json
@@ -96,6 +96,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/conformance/vectors/AH-CTK-103-approve-carrying-failing-transform.json
+++ b/conformance/vectors/AH-CTK-103-approve-carrying-failing-transform.json
@@ -94,6 +94,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/sdk/dotnet/src/AgentHooks.Conformance/IHarness.cs
+++ b/sdk/dotnet/src/AgentHooks.Conformance/IHarness.cs
@@ -114,6 +114,16 @@ public interface IHarness
     string Name { get; }
     IReadOnlySet<Capability> Capabilities { get; }
 
+    /// <summary>Declared §6.2 posture at the tool seam (§13.1): what the
+    /// host does with the run after a <c>host_error:*</c> deny at
+    /// <c>pre_tool_call</c>/<c>post_tool_call</c>. <c>"continue"</c> (the
+    /// default — surface a tool error to the model and keep the loop
+    /// going) or <c>"terminate"</c> (the host's own semantics terminate
+    /// the turn, which §6.2 explicitly permits). The runner forwards this
+    /// declaration so <c>expect.run_outcome_by_posture</c> vectors resolve
+    /// to the single outcome this surface must produce.</summary>
+    string ToolSeamHostError => "continue";
+
     /// <summary>Wire the scenario's mock model + tools into the framework,
     /// register the interceptors and resolver, set the enforcement mode,
     /// the vector's composition profile (§7.1), and its identity provider

--- a/sdk/dotnet/src/AgentHooks.Conformance/Runner.cs
+++ b/sdk/dotnet/src/AgentHooks.Conformance/Runner.cs
@@ -115,7 +115,7 @@ public static class Runner
 
         var recordedJson = new JsonArray(
             recorded.Select(c => (JsonNode)c).ToArray()).ToJsonString(Compact);
-        var rrJson = RunRecordToWire(rr);
+        var rrJson = RunRecordToWire(rr, harness.ToolSeamHostError);
         var result = (JsonObject)JsonNode.Parse(
             Native.CtkAssert(vectorJson, recordedJson, rrJson))!;
         return new VectorResult(
@@ -126,7 +126,7 @@ public static class Runner
             (result["failures"] as JsonArray)?.Select(n => (string)n!).ToList() ?? []);
     }
 
-    private static string RunRecordToWire(RunRecord rr)
+    private static string RunRecordToWire(RunRecord rr, string toolSeamHostError)
     {
         var identities = new JsonArray();
         foreach (var (i, e) in rr.Identities ?? [])
@@ -146,6 +146,12 @@ public static class Runner
             ["error"] = rr.Error,
             ["identities"] = identities,
             ["records"] = records,
+            // Harness *declarations* (§13.1), not observed behavior: the
+            // engine selects expect.run_outcome_by_posture entries by them.
+            ["postures"] = new JsonObject
+            {
+                ["tool_seam_host_error"] = toolSeamHostError,
+            },
         };
         return o.ToJsonString(Compact);
     }

--- a/sdk/go/conformance/harness.go
+++ b/sdk/go/conformance/harness.go
@@ -108,3 +108,16 @@ type Harness interface {
 
 	Teardown()
 }
+
+// ToolSeamHostErrorDeclarer is an optional Harness extension declaring
+// the host's §6.2 posture at the tool seam (§13.1): what the host does
+// with the run after a host_error:* deny at pre_tool_call /
+// post_tool_call. "continue" (the default — surface a tool error to
+// the model and keep the loop going) or "terminate" (the host's own
+// semantics terminate the turn, which §6.2 explicitly permits). A
+// Harness that does not implement it declares the default. The runner
+// forwards this declaration so expect.run_outcome_by_posture vectors
+// resolve to the single outcome this surface must produce.
+type ToolSeamHostErrorDeclarer interface {
+	ToolSeamHostError() string
+}

--- a/sdk/go/conformance/runner.go
+++ b/sdk/go/conformance/runner.go
@@ -97,7 +97,7 @@ func mustJSON(v any) string {
 	return string(b)
 }
 
-func runRecordToWire(rr RunRecord) string {
+func runRecordToWire(rr RunRecord, postures map[string]string) string {
 	invs := make([]map[string]any, len(rr.ToolInvocations))
 	for i, t := range rr.ToolInvocations {
 		invs[i] = map[string]any{"name": t.Name, "args": t.Args}
@@ -122,6 +122,9 @@ func runRecordToWire(rr RunRecord) string {
 		"error":            rr.Err,
 		"identities":       ids,
 		"records":          records,
+		// Harness *declarations* (§13.1), not observed behavior: the
+		// engine selects expect.run_outcome_by_posture entries by them.
+		"postures": postures,
 	})
 }
 
@@ -228,7 +231,14 @@ func RunVector(ctx context.Context, h Harness, vector map[string]any) (VectorRes
 	if first != nil {
 		recorded = first.recorded
 	}
-	return agenthooks.CtkAssert(vectorJSON, recorded, runRecordToWire(rr))
+	// §13.1 posture declaration; a Harness that does not implement the
+	// optional declarer interface declares the spec default.
+	posture := "continue"
+	if d, ok := h.(ToolSeamHostErrorDeclarer); ok {
+		posture = d.ToolSeamHostError()
+	}
+	postures := map[string]string{"tool_seam_host_error": posture}
+	return agenthooks.CtkAssert(vectorJSON, recorded, runRecordToWire(rr, postures))
 }
 
 func scenarioFromWire(s map[string]any) Scenario {

--- a/sdk/python/python/agent_hooks/ctk/harness.py
+++ b/sdk/python/python/agent_hooks/ctk/harness.py
@@ -128,6 +128,15 @@ class Harness(Protocol):
 
     name: str
     capabilities: set[Capability]
+    #: Declared §6.2 posture at the tool seam (§13.1): what the host does
+    #: with the run after a ``host_error:*`` deny at
+    #: ``pre_tool_call``/``post_tool_call``. ``"continue"`` (the default —
+    #: surface a tool error to the model and keep the loop going) or
+    #: ``"terminate"`` (the host's own semantics terminate the turn, which
+    #: §6.2 explicitly permits). The runner forwards this declaration so
+    #: ``expect.run_outcome_by_posture`` vectors resolve to the single
+    #: outcome this surface must produce.
+    tool_seam_host_error: str = "continue"
 
     def setup(
         self,

--- a/sdk/python/python/agent_hooks/ctk/runner.py
+++ b/sdk/python/python/agent_hooks/ctk/runner.py
@@ -71,7 +71,7 @@ def load_vectors(directory: str | pathlib.Path | None = None) -> list[dict[str, 
     return vectors
 
 
-def _run_record_to_wire(rr: RunRecord) -> str:
+def _run_record_to_wire(rr: RunRecord, postures: dict[str, str]) -> str:
     return dumps(
         {
             "outcome": rr.outcome.value,
@@ -80,6 +80,9 @@ def _run_record_to_wire(rr: RunRecord) -> str:
             "error": rr.error,
             "identities": [{"input_identity": i, "enforced_identity": e} for i, e in rr.identities],
             "records": rr.records,
+            # Harness *declarations* (§13.1), not observed behavior: the
+            # engine selects expect.run_outcome_by_posture entries by them.
+            "postures": postures,
         }
     )
 
@@ -130,11 +133,14 @@ async def run_vector(harness: Harness, vector: dict[str, Any]) -> VectorResult:
     finally:
         harness.teardown()
 
+    # §13.1 posture declaration; getattr keeps structural (non-subclass)
+    # Harness implementations working — absent means the spec default.
+    postures = {"tool_seam_host_error": getattr(harness, "tool_seam_host_error", "continue")}
     result = json.loads(
         _core.ctk_assert(
             vector_json,
             dumps(first.recorded if first else []),
-            _run_record_to_wire(rr),
+            _run_record_to_wire(rr, postures),
         )
     )
     return VectorResult(

--- a/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-070-interceptor-raises.json
+++ b/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-070-interceptor-raises.json
@@ -21,6 +21,10 @@
     ],
     "interceptions_absent": ["post_tool_call"],
     "tool_not_invoked": ["http_get"],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-071-malformed-verdict.json
+++ b/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-071-malformed-verdict.json
@@ -21,6 +21,10 @@
     ],
     "interceptions_absent": ["post_tool_call"],
     "tool_not_invoked": ["http_get"],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-072-resolver-identity-mismatch.json
+++ b/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-072-resolver-identity-mismatch.json
@@ -91,6 +91,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-073-resolver-raises.json
+++ b/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-073-resolver-raises.json
@@ -86,6 +86,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-085-parallel-transform-conflict-deny.json
+++ b/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-085-parallel-transform-conflict-deny.json
@@ -96,6 +96,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-087-unanimous-disagreement-deny.json
+++ b/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-087-unanimous-disagreement-deny.json
@@ -93,6 +93,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-092-evidence-cap.json
+++ b/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-092-evidence-cap.json
@@ -80,6 +80,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-094-failure-deny-attribution.json
+++ b/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-094-failure-deny-attribution.json
@@ -86,6 +86,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-095-postfold-domain-rejection.json
+++ b/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-095-postfold-domain-rejection.json
@@ -85,6 +85,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-097-runall-failure-slot.json
+++ b/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-097-runall-failure-slot.json
@@ -72,7 +72,11 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   },
   "composition": {
     "profile": "sequential/run_all"

--- a/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-098-approve-carrying-deny.json
+++ b/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-098-approve-carrying-deny.json
@@ -91,6 +91,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-100-deny-post-tool-non-incorporation.json
+++ b/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-100-deny-post-tool-non-incorporation.json
@@ -1,6 +1,6 @@
 {
   "id": "AH-CTK-100",
-  "title": "deny at post_tool_call: the tool result is discarded, not incorporated into agent state (§6.1)",
+  "title": "deny at post_tool_call: the tool result is discarded, not incorporated into agent state; the deny surfaces to the model in some form, transcript shape unprescribed (§6.1)",
   "spec_clause": "6.1, 6.2",
   "part": "enforcement/post_action_deny",
   "capabilities": [
@@ -67,9 +67,15 @@
       },
       {
         "interception_point": "pre_model_call",
-        "context": {
-          "messages[1].role": "tool",
-          "messages[1].content": "blocked: ctk:tainted-result"
+        "context_must_contain": ["ctk:tainted-result"],
+        "context_must_not_contain": ["SECRET-RESULT"]
+      }
+    ],
+    "tool_invocations": [
+      {
+        "name": "http_get",
+        "args": {
+          "url": "https://x"
         }
       }
     ],

--- a/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-102-runall-failed-transform-shortcircuit.json
+++ b/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-102-runall-failed-transform-shortcircuit.json
@@ -96,6 +96,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-103-approve-carrying-failing-transform.json
+++ b/sdk/python/python/agent_hooks/ctk/vectors/AH-CTK-103-approve-carrying-failing-transform.json
@@ -94,6 +94,10 @@
         }
       }
     ],
-    "run_outcome": "completed"
+    "run_outcome": "completed",
+    "run_outcome_by_posture": {
+      "posture": "tool_seam_host_error",
+      "outcomes": { "continue": "completed", "terminate": "blocked" }
+    }
   }
 }

--- a/sdk/rust/core/src/ctk.rs
+++ b/sdk/rust/core/src/ctk.rs
@@ -170,6 +170,18 @@ pub trait Harness: Send {
     /// (`"model_calls"`, `"tool_calls"`, …).
     fn capabilities(&self) -> Vec<String>;
 
+    /// Declared §6.2 posture at the tool seam (§13.1): what the host
+    /// does with the run after a `host_error:*` deny at
+    /// `pre_tool_call`/`post_tool_call`. `"continue"` (the default —
+    /// surface a tool error to the model and keep the loop going) or
+    /// `"terminate"` (the host's own semantics terminate the turn,
+    /// which §6.2 explicitly permits). The runner forwards this
+    /// declaration so `expect.run_outcome_by_posture` vectors resolve
+    /// to the single outcome this surface must produce.
+    fn tool_seam_host_error(&self) -> &str {
+        "continue"
+    }
+
     /// Wire one vector into the framework: the scenario's mock model +
     /// tools, the interceptors and resolver, the enforcement mode, the
     /// vector's composition profile (§7.1), its identity provider
@@ -285,8 +297,14 @@ pub async fn run_vector(harness: &mut dyn Harness, vector: &Value) -> VectorResu
         identity_provider,
         redact_for_approval,
     });
-    let rr = harness.run().await;
+    let posture = harness.tool_seam_host_error().to_owned();
+    let mut rr = harness.run().await;
     harness.teardown();
+
+    // Forward the harness's declared posture (§13.1) so the engine can
+    // select the expected run_outcome where the spec permits both.
+    rr.postures
+        .insert("tool_seam_host_error".to_owned(), posture);
 
     let recorded = recorded.lock().expect("recorder poisoned").clone();
     assert_vector(vector, &recorded, &rr)
@@ -541,6 +559,8 @@ impl Harness for ReferenceHarness {
                 .iter()
                 .map(|r| serde_json::to_value(r).expect("record serializes"))
                 .collect(),
+            // The runner overwrites this from the Harness declaration.
+            postures: Default::default(),
         }
     }
 

--- a/sdk/rust/core/src/ctk_engine.rs
+++ b/sdk/rust/core/src/ctk_engine.rs
@@ -164,7 +164,7 @@ pub struct IdentityPair {
 }
 
 /// Wire-shaped `RunRecord` the harness returns.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct RunRecord {
     pub outcome: String,
     #[serde(default)]
@@ -184,6 +184,14 @@ pub struct RunRecord {
     /// combined-verdict content).
     #[serde(default)]
     pub records: Vec<Value>,
+    /// Host-declared postures (§13.1), forwarded by the runner from the
+    /// harness *declaration* — never inferred from observed behavior.
+    /// Known key: `tool_seam_host_error` = `"continue"` (the §6.2
+    /// default) or `"terminate"` (the host's own semantics terminate
+    /// the turn on a `host_error:*` deny at the tool seam). A missing
+    /// key means the spec-default posture.
+    #[serde(default)]
+    pub postures: std::collections::BTreeMap<String, String>,
 }
 
 /// Result of one vector run.
@@ -288,6 +296,41 @@ fn assert_interceptions(expect: &Value, recorded: &[Value], failures: &mut Vec<S
                 }
             }
         }
+        // Whole-context substring assertions (shape-agnostic): pin that
+        // content surfaced (in SOME form) or never surfaced (e.g. a
+        // §6.1-discarded tool result), without prescribing message
+        // layout or payload format. Matched against the serialized
+        // recorded context; needles should avoid JSON-escaped
+        // characters (quotes, backslashes, control chars).
+        let needs_scan =
+            e.get("context_must_contain").is_some() || e.get("context_must_not_contain").is_some();
+        if needs_scan {
+            let serialized = serde_json::to_string(r).unwrap_or_default();
+            for n in e
+                .get("context_must_contain")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+            {
+                if !serialized.contains(n) {
+                    failures.push(format!("{ip}: context does not contain {n:?} in any form"));
+                }
+            }
+            for n in e
+                .get("context_must_not_contain")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+            {
+                if serialized.contains(n) {
+                    failures.push(format!(
+                        "{ip}: context contains {n:?}, which MUST NOT surface here"
+                    ));
+                }
+            }
+        }
     }
 
     if let Some(absent) = expect.get("interceptions_absent").and_then(Value::as_array) {
@@ -303,8 +346,62 @@ fn assert_interceptions(expect: &Value, recorded: &[Value], failures: &mut Vec<S
     }
 }
 
+/// The spec-default value for a declarable host posture (§13.1).
+/// `tool_seam_host_error`: §6.2's continue rule is the default reading;
+/// "terminate" is the explicitly permitted alternative ("unless the
+/// host's own semantics terminate the turn").
+fn posture_default(posture: &str) -> Option<&'static str> {
+    match posture {
+        "tool_seam_host_error" => Some("continue"),
+        _ => None,
+    }
+}
+
+/// Resolve the expected `run_outcome` for this harness's declared
+/// postures. `expect.run_outcome` stays the single value for the
+/// spec-default posture (so pre-posture runners keep working for
+/// default-posture hosts); `expect.run_outcome_by_posture`, where
+/// present, selects by the posture the runner forwarded in
+/// `RunRecord.postures` where the spec permits both behaviors.
+fn expected_outcome(expect: &Value, rr: &RunRecord, failures: &mut Vec<String>) -> String {
+    let base = expect["run_outcome"].as_str().unwrap_or("").to_owned();
+    let Some(by) = expect.get("run_outcome_by_posture") else {
+        return base;
+    };
+    let posture = by.get("posture").and_then(Value::as_str).unwrap_or("");
+    let Some(default) = posture_default(posture) else {
+        failures.push(format!(
+            "run_outcome_by_posture names unknown posture {posture:?}"
+        ));
+        return base;
+    };
+    let outcomes = &by["outcomes"];
+    // Vector-authoring integrity: the default-posture outcome MUST
+    // equal run_outcome, or pre-posture runners and posture-aware
+    // runners would disagree about the same default-posture host.
+    if outcomes.get(default).and_then(Value::as_str) != Some(base.as_str()) {
+        failures.push(format!(
+            "vector error: run_outcome_by_posture.outcomes.{default} must equal run_outcome {base:?}"
+        ));
+    }
+    let declared = rr
+        .postures
+        .get(posture)
+        .map(String::as_str)
+        .unwrap_or(default);
+    match outcomes.get(declared).and_then(Value::as_str) {
+        Some(o) => o.to_owned(),
+        None => {
+            failures.push(format!(
+                "declared posture {posture}={declared:?} has no outcome in run_outcome_by_posture"
+            ));
+            base
+        }
+    }
+}
+
 fn assert_record(expect: &Value, rr: &RunRecord, failures: &mut Vec<String>) {
-    let want_outcome = expect["run_outcome"].as_str().unwrap_or("");
+    let want_outcome = expected_outcome(expect, rr, failures);
     if rr.outcome != want_outcome {
         failures.push(format!(
             "run_outcome == {:?}, want {want_outcome:?}",
@@ -577,6 +674,121 @@ mod tests {
         assert!(should_skip(&v, &["model_calls", "tool_calls"]).is_none());
     }
 
+    fn posture_vector() -> Value {
+        json!({
+            "id": "T", "title": "t",
+            "expect": {
+                "interceptions": [],
+                "run_outcome": "completed",
+                "run_outcome_by_posture": {
+                    "posture": "tool_seam_host_error",
+                    "outcomes": { "continue": "completed", "terminate": "blocked" }
+                }
+            }
+        })
+    }
+
+    fn rr_with(outcome: &str, posture: Option<&str>) -> RunRecord {
+        let mut rr = RunRecord {
+            outcome: outcome.into(),
+            ..Default::default()
+        };
+        if let Some(p) = posture {
+            rr.postures.insert("tool_seam_host_error".into(), p.into());
+        }
+        rr
+    }
+
+    #[test]
+    fn run_outcome_selected_by_declared_posture() {
+        let v = posture_vector();
+        // Default (undeclared) posture = continue.
+        assert_eq!(
+            assert_vector(&v, &[], &rr_with("completed", None)).status,
+            "pass"
+        );
+        // Explicit continue.
+        let r = assert_vector(&v, &[], &rr_with("completed", Some("continue")));
+        assert_eq!(r.status, "pass", "{:?}", r.failures);
+        // Declared terminate host: blocked is the expected outcome …
+        let r = assert_vector(&v, &[], &rr_with("blocked", Some("terminate")));
+        assert_eq!(r.status, "pass", "{:?}", r.failures);
+        // … and completed now fails.
+        let r = assert_vector(&v, &[], &rr_with("completed", Some("terminate")));
+        assert_eq!(r.status, "fail");
+        // A continue host reporting blocked still fails.
+        let r = assert_vector(&v, &[], &rr_with("blocked", None));
+        assert_eq!(r.status, "fail");
+    }
+
+    #[test]
+    fn run_outcome_by_posture_authoring_errors() {
+        // Unknown posture name fails loudly.
+        let mut v = posture_vector();
+        v["expect"]["run_outcome_by_posture"]["posture"] = json!("no_such_posture");
+        let r = assert_vector(&v, &[], &rr_with("completed", None));
+        assert_eq!(r.status, "fail");
+        assert!(
+            r.failures[0].contains("unknown posture"),
+            "{:?}",
+            r.failures
+        );
+        // Default-posture outcome disagreeing with run_outcome fails.
+        let mut v = posture_vector();
+        v["expect"]["run_outcome_by_posture"]["outcomes"]["continue"] = json!("blocked");
+        let r = assert_vector(&v, &[], &rr_with("completed", None));
+        assert_eq!(r.status, "fail");
+        // A declared posture value the vector does not cover fails.
+        let v = posture_vector();
+        let r = assert_vector(&v, &[], &rr_with("blocked", Some("halt")));
+        assert_eq!(r.status, "fail");
+        assert!(
+            r.failures.iter().any(|f| f.contains("has no outcome")),
+            "{:?}",
+            r.failures
+        );
+    }
+
+    #[test]
+    fn context_substring_assertions() {
+        let vector = json!({
+            "id": "T", "title": "t",
+            "expect": {
+                "sequence_strict": false,
+                "interceptions": [{
+                    "interception_point": "pre_model_call",
+                    "context_must_validate": false,
+                    "context_must_contain": ["ctk:tainted-result"],
+                    "context_must_not_contain": ["SECRET-RESULT"]
+                }],
+                "run_outcome": "completed"
+            }
+        });
+        let ok = vec![json!({
+            "interception_point": "pre_model_call", "sequence": 0,
+            "messages": [{"role": "tool", "content": {"error": true, "reason": "ctk:tainted-result"}}]
+        })];
+        let r = assert_vector(&vector, &ok, &rr_with("completed", None));
+        assert_eq!(r.status, "pass", "{:?}", r.failures);
+
+        let leaky = vec![json!({
+            "interception_point": "pre_model_call", "sequence": 0,
+            "messages": [{"role": "tool", "content": "SECRET-RESULT"}]
+        })];
+        let r = assert_vector(&vector, &leaky, &rr_with("completed", None));
+        assert_eq!(r.status, "fail");
+        assert!(
+            r.failures.iter().any(|f| f.contains("MUST NOT surface")),
+            "{:?}",
+            r.failures
+        );
+        assert!(
+            r.failures.iter().any(|f| f.contains("in any form")),
+            "{:?}",
+            r.failures
+        );
+    }
+
     #[test]
     fn assert_vector_pass() {
         let vector = json!({
@@ -596,11 +808,7 @@ mod tests {
         })];
         let rr = RunRecord {
             outcome: "completed".into(),
-            final_output: Value::Null,
-            tool_invocations: vec![],
-            error: None,
-            identities: vec![],
-            records: vec![],
+            ..Default::default()
         };
         let r = assert_vector(&vector, &recorded, &rr);
         assert_eq!(r.status, "pass", "{:?}", r.failures);

--- a/sdk/rust/core/tests/ctk_external_harness.rs
+++ b/sdk/rust/core/tests/ctk_external_harness.rs
@@ -28,11 +28,7 @@ impl Harness for ExternalHarness {
     async fn run(&mut self) -> RunRecord {
         RunRecord {
             outcome: "completed".into(),
-            final_output: json!(null),
-            tool_invocations: Vec::new(),
-            error: None,
-            identities: Vec::new(),
-            records: Vec::new(),
+            ..Default::default()
         }
     }
 

--- a/sdk/typescript/src/ctk/index.ts
+++ b/sdk/typescript/src/ctk/index.ts
@@ -66,6 +66,16 @@ export interface Harness {
   readonly name: string;
   readonly capabilities: ReadonlySet<Capability>;
 
+  /** Declared §6.2 posture at the tool seam (§13.1): what the host does
+   * with the run after a `host_error:*` deny at
+   * `pre_tool_call`/`post_tool_call`. `"continue"` (the default —
+   * surface a tool error to the model and keep the loop going) or
+   * `"terminate"` (the host's own semantics terminate the turn, which
+   * §6.2 explicitly permits). The runner forwards this declaration so
+   * `expect.run_outcome_by_posture` vectors resolve to the single
+   * outcome this surface must produce. */
+  readonly toolSeamHostError?: "continue" | "terminate";
+
   /** Wire the scenario's mock model + tools into the framework,
    * register the interceptors and resolver, set the enforcement mode,
    * the vector's composition profile (§7.1), and its identity provider

--- a/sdk/typescript/src/ctk/runner.ts
+++ b/sdk/typescript/src/ctk/runner.ts
@@ -106,7 +106,7 @@ class ScriptedResolver {
   }
 }
 
-function runRecordToWire(rr: RunRecord): string {
+function runRecordToWire(rr: RunRecord, postures: Record<string, string>): string {
   return JSON.stringify({
     outcome: rr.outcome,
     final_output: rr.final_output ?? null,
@@ -114,6 +114,9 @@ function runRecordToWire(rr: RunRecord): string {
     error: rr.error ?? null,
     identities: rr.identities.map(([i, e]) => ({ input_identity: i, enforced_identity: e })),
     records: rr.records,
+    // Harness *declarations* (§13.1), not observed behavior: the engine
+    // selects expect.run_outcome_by_posture entries by them.
+    postures,
   });
 }
 
@@ -184,8 +187,14 @@ export async function runVector(harness: Harness, vector: JsonValue): Promise<Ve
     harness.teardown();
   }
 
+  // §13.1 posture declaration; absent means the spec default.
+  const postures = { tool_seam_host_error: harness.toolSeamHostError ?? "continue" };
   return JSON.parse(
-    native.ctkAssert(vectorJson, JSON.stringify(first?.recorded ?? []), runRecordToWire(rr)),
+    native.ctkAssert(
+      vectorJson,
+      JSON.stringify(first?.recorded ?? []),
+      runRecordToWire(rr, postures),
+    ),
   );
 }
 

--- a/spec/AGENT-HOOKS-0.1.md
+++ b/spec/AGENT-HOOKS-0.1.md
@@ -1268,7 +1268,15 @@ There are no conformance tiers, levels, or baseline profiles. A host
   under the §12.1 exception; gates the `streaming/incremental`
   vectors),
 - the composition profiles and knob values it supports (§7.2),
-- its identity provider (§10.1).
+- its identity provider (§10.1),
+- its posture where this specification permits two behaviors:
+  `tool_seam_host_error: continue | terminate` (default `continue`) —
+  whether a `host_error:*` deny at `pre_tool_call`/`post_tool_call`
+  continues the agent loop per §6.2's continue rule or terminates the
+  turn under §6.2's "unless the host's own semantics terminate the
+  turn" clause. The CTK resolves posture-conditional expectations
+  against this declaration, so each declared surface is tested against
+  a single expected outcome.
 
 A host is **conformant** when it passes 100% of the CTK vectors
 applicable to its declaration. The CTK emits a **conformance report**
@@ -1302,6 +1310,9 @@ runners are provided under `sdk/<lang>/`.
 A conformance claim is the tuple
 `(<framework>, <adapter-version>, agent-hooks/<spec-version>, <capabilities>, <profiles>, <identity-provider>, <sdk-lang>@<sdk-version>)`
 plus the CTK report, recorded in `conformance/CLAIMS.md`. A claim with
+a non-default posture (§13.1) MUST state it (e.g.
+`tool_seam_host_error: terminate`) — the report's passing vectors
+attest that posture's outcomes, not the default's. A claim with
 `identity_provider: null` MUST state that its approvals and records are
 identity-unbound. A claim with `buffered_output: false` MUST state
 that a `deny` at `output` cannot retract already-streamed content


### PR DESCRIPTION
Fixes the two CTK issues blocking an honest MAF conformance claim (found by the cross-validation in `conformance/claims/maf/`, PR #66).

## #68 — declared `tool_seam_host_error` posture

§6.2 permits two behaviors after a `host_error:*` deny at the tool seam: continue the loop (surface a tool error to the model) or terminate the turn ("unless the host's own semantics terminate the turn"). The CTK's single-valued `run_outcome` could only express the first.

Design — **declared posture, not outcome sets**: the harness declares `tool_seam_host_error: continue | terminate` (default `continue`) alongside its capabilities, the runner forwards the declaration in the run-record wire (`postures.tool_seam_host_error`), and the engine resolves the new `expect.run_outcome_by_posture` to the single outcome that declared surface must produce. A pass never means "one of several outcomes happened", so claims stay honest and vectors stay single-valued per declared surface.

Backward compatibility is deliberate: `run_outcome` keeps the default-posture value and the engine enforces it equals `run_outcome_by_posture.outcomes.continue`, so **pre-posture runners still resolve the corpus correctly for continue hosts** — verified against agent-control-spec's pinned `agent-hooks-sdk 0.1.0-alpha.3` engine (below).

- 13 vectors gain the posture-conditional outcome: AH-CTK-070–073, 085, 087, 092, 094–095, 097–098, 102–103 (all `pre_tool_call` `host_error:*` denies).
- All five SDK Harness contracts gain the declaration with a `continue` default: Python attribute, TypeScript optional readonly, Go optional `ToolSeamHostErrorDeclarer` interface, .NET default interface member, Rust default trait method. Reference self-tests are unchanged by construction (every reference host continues).
- Spec §13.1 adds the posture to the declared surface; §13.3 + `CLAIMS.md` require non-default postures to be stated in the claim.

## #69 — AH-CTK-100 asserts §6.1/§6.2 substance, not transcript cosmetics

The vector pinned the reference host's conventions (tool message at `messages[1]`, content exactly `"blocked: <reason>"`). It now asserts only the normative properties, via two new shape-agnostic interception assertions (`context_must_contain` / `context_must_not_contain`, substring scans over the serialized recorded context):

- the denied tool result (`SECRET-RESULT`) never surfaces at the next `pre_model_call` in any form (§6.1 non-incorporation),
- the deny reason surfaces to the model in SOME form (§6.2), payload shape and message layout host-defined,
- the tool was invoked exactly once (`tool_invocations`), plus the existing deny-record assertion.

## Verification

| Suite | Result |
| --- | --- |
| Rust workspace (`--all-features`, incl. new engine unit tests) | green |
| Python (`pytest sdk/python/tests`) | 181 passed, 6 skipped |
| .NET (`dotnet test`) | 122 passed |
| TypeScript (`node --test`) | 131 passed |
| ajv over the amended schema | all 51 vectors valid |
| Posture forwarding (Python, terminate-declared probe) | 13 vectors flip to expecting `blocked` |
| **ACS cross-check** (corpus swapped under its pinned alpha.3 engine) | **46 passed, 0 failed, 5 capability-gated skips of 51** — baseline surface intact |

Closes #68
Closes #69